### PR TITLE
Add modern About page and navigation link

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1313,6 +1313,201 @@ body.ts-page {
     }
 }
 
+
+.ts-about-intro {
+    padding-bottom: clamp(3.5rem, 6vw, 4.5rem);
+}
+
+.ts-about-callout {
+    align-self: stretch;
+    background: rgba(255, 255, 255, 0.94);
+    border-radius: var(--radius-lg);
+    padding: clamp(1.75rem, 3vw, 2.5rem);
+    box-shadow: 0 28px 48px rgba(60, 74, 31, 0.16);
+    display: grid;
+    gap: 1.1rem;
+}
+
+.ts-about-callout h3 {
+    margin: 0;
+    font-size: 1.4rem;
+    color: var(--color-olive-dark);
+}
+
+.ts-about-callout__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.65rem;
+    color: var(--color-muted);
+}
+
+.ts-about-callout__list li {
+    position: relative;
+    padding-left: 1.4rem;
+}
+
+.ts-about-callout__list li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.45rem;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--color-yellow), var(--color-orange));
+}
+
+.ts-about-expertise {
+    padding: clamp(4rem, 6vw, 5rem) 0;
+}
+
+.ts-about-expertise__grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.ts-about-expertise__card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: var(--radius-lg);
+    padding: clamp(1.6rem, 3vw, 2.2rem);
+    box-shadow: 0 30px 56px rgba(60, 74, 31, 0.14);
+    display: grid;
+    gap: 0.85rem;
+}
+
+.ts-about-expertise__card h3 {
+    margin: 0;
+    font-size: 1.3rem;
+    color: var(--color-olive-dark);
+}
+
+.ts-about-expertise__card p {
+    margin: 0;
+    color: var(--color-muted);
+    line-height: 1.7;
+}
+
+.ts-about-competencies {
+    padding: clamp(4rem, 6vw, 5rem) 0;
+    background: linear-gradient(135deg, rgba(245, 241, 227, 0.72), rgba(246, 196, 69, 0.24));
+}
+
+.ts-competency-list {
+    list-style: none;
+    margin: clamp(2rem, 3vw, 2.75rem) 0 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.ts-competency-item {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: var(--radius-md);
+    padding: 1.1rem 1.4rem 1.25rem;
+    box-shadow: 0 20px 40px rgba(60, 74, 31, 0.12);
+    display: grid;
+    gap: 0.6rem;
+}
+
+.ts-competency-item__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.ts-competency-item__header strong {
+    color: var(--color-olive-dark);
+}
+
+.ts-competency-bar {
+    position: relative;
+    height: 10px;
+    border-radius: 999px;
+    background: rgba(85, 107, 47, 0.15);
+    overflow: hidden;
+}
+
+.ts-competency-fill {
+    position: absolute;
+    inset: 0;
+    width: var(--progress, 0%);
+    border-radius: inherit;
+    background: linear-gradient(135deg, var(--color-yellow), var(--color-orange));
+    transition: width 0.6s ease;
+}
+
+.ts-about-accreditation {
+    padding: clamp(4.5rem, 7vw, 5.5rem) 0;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(245, 241, 227, 0.68) 100%);
+}
+
+.ts-about-accreditation__grid {
+    display: grid;
+    gap: clamp(2rem, 4vw, 3rem);
+    grid-template-columns: minmax(0, 1.1fr) minmax(240px, 320px);
+    align-items: start;
+}
+
+.ts-about-accreditation__content > *:first-child {
+    margin-top: 0;
+}
+
+.ts-about-accreditation__side {
+    display: grid;
+    gap: 1.5rem;
+    align-content: start;
+}
+
+.ts-about-accreditation__badge {
+    margin: 0;
+    padding: 1.25rem;
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 26px 48px rgba(60, 74, 31, 0.16);
+    text-align: center;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.ts-about-accreditation__badge img {
+    width: 100%;
+    height: auto;
+}
+
+.ts-about-accreditation__badge figcaption {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--color-olive-dark);
+}
+
+.ts-about-partner-card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    box-shadow: 0 24px 44px rgba(60, 74, 31, 0.14);
+    display: grid;
+    gap: 0.75rem;
+    text-align: center;
+}
+
+.ts-about-partner-card img {
+    justify-self: center;
+    width: min(200px, 70%);
+    height: auto;
+}
+
+.ts-about-partner-card p {
+    margin: 0;
+    color: var(--color-muted);
+    line-height: 1.6;
+}
+
 .ts-faq {
     padding: 4rem 0;
 }
@@ -2238,6 +2433,14 @@ body.ts-page {
     .ts-article-detail__content {
         padding: 32px;
     }
+    .ts-about-accreditation__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .ts-about-accreditation__side {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
 }
 
 @media (max-width: 768px) {
@@ -2268,6 +2471,24 @@ body.ts-page {
     .ts-subheader__scroll-icon {
         width: 32px;
         height: 50px;
+    }
+
+    .ts-about-callout {
+        padding: 1.5rem;
+    }
+
+    .ts-competency-list {
+        gap: 0.85rem;
+    }
+
+    .ts-competency-item {
+        padding: 1rem 1.2rem 1.1rem;
+    }
+
+    .ts-competency-item__header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
     }
 
     .ts-floating-cta {

--- a/assets/images/accreditation-badge.svg
+++ b/assets/images/accreditation-badge.svg
@@ -1,0 +1,38 @@
+<svg width="320" height="360" viewBox="0 0 320 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="badgeGradient" x1="20" y1="30" x2="300" y2="320" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#F6C445" />
+            <stop offset="1" stop-color="#F2994A" />
+        </linearGradient>
+        <linearGradient id="badgeInner" x1="70" y1="70" x2="250" y2="280" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#FFFFFF" stop-opacity="0.85" />
+            <stop offset="1" stop-color="#FFF4D4" stop-opacity="0.95" />
+        </linearGradient>
+        <filter id="shadow" x="-20" y="-20" width="360" height="400" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="rgba(60,74,31,0.22)" />
+        </filter>
+    </defs>
+    <g filter="url(#shadow)">
+        <rect x="20" y="20" width="280" height="320" rx="28" fill="url(#badgeGradient)" />
+        <rect x="38" y="42" width="244" height="276" rx="22" fill="url(#badgeInner)" />
+        <path
+            d="M160 88C189.271 88 212.984 111.713 212.984 140.984C212.984 170.255 189.271 193.968 160 193.968C130.729 193.968 107.016 170.255 107.016 140.984C107.016 111.713 130.729 88 160 88Z"
+            fill="#F6C445"
+            opacity="0.32"
+        />
+        <circle cx="160" cy="140" r="52" fill="url(#badgeGradient)" opacity="0.85" />
+        <path
+            d="M160 109L172.944 137.056L203 140.984L179.5 161L185.888 190L160 174.944L134.112 190L140.5 161L117 140.984L147.056 137.056L160 109Z"
+            fill="#fffef9"
+        />
+        <text x="50%" y="230" text-anchor="middle" font-family="'Manrope', 'Arial', sans-serif" font-weight="700" font-size="22" fill="#3C4A1F">
+            Минцифры России
+        </text>
+        <text x="50%" y="258" text-anchor="middle" font-family="'Manrope', 'Arial', sans-serif" font-weight="500" font-size="15" fill="#5E6B3A">
+            Аккредитованная IT-компания
+        </text>
+        <text x="50%" y="288" text-anchor="middle" font-family="'Manrope', 'Arial', sans-serif" font-weight="600" font-size="14" fill="#5E6B3A">
+            № 65513 / АО-20241115-21414046354-3
+        </text>
+    </g>
+</svg>

--- a/assets/images/partner-sls.svg
+++ b/assets/images/partner-sls.svg
@@ -1,0 +1,17 @@
+<svg width="260" height="120" viewBox="0 0 260 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="partnerBg" x1="0" y1="0" x2="260" y2="120" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#F6F1E3" />
+            <stop offset="1" stop-color="#FFF8DA" />
+        </linearGradient>
+    </defs>
+    <rect x="2" y="2" width="256" height="116" rx="18" fill="url(#partnerBg)" stroke="#F2A24A" stroke-width="2" />
+    <g font-family="'Manrope', 'Arial', sans-serif" fill="#3C4A1F">
+        <text x="28" y="54" font-size="26" font-weight="700">SLS</text>
+        <text x="94" y="54" font-size="26" font-weight="700" fill="#F2994A">Partner</text>
+        <text x="28" y="86" font-size="14" font-weight="600" fill="#5E6B3A">Официальный партнёр Technostation</text>
+    </g>
+    <circle cx="208" cy="60" r="22" fill="#F6C445" opacity="0.25" />
+    <circle cx="208" cy="60" r="16" fill="#F2994A" opacity="0.55" />
+    <path d="M208 46L214 60L208 74L202 60L208 46Z" fill="#fffef9" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
                 <ul class="ts-nav__links">
                     <li><a href="#ts-services">Услуги</a></li>
                     <li><a href="#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="#ts-pricing">Цены</a></li>
                     <li><a href="#ts-faq">FAQ</a></li>
                     <li><a href="#ts-contact">Контакты</a></li>
@@ -1181,6 +1182,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/individualnyij-podxod.html
+++ b/individualnyij-podxod.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -162,6 +163,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/maksimum.html
+++ b/maksimum.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -162,6 +163,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/o-nas.html
+++ b/o-nas.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>О компании Technostation: AI-RPA — Эксперты по роботизации</title>
+    <meta
+        name="description"
+        content="Technostation: AI-RPA — команда экспертов по роботизации бизнес-процессов. Мы создаём решения на базе AI RPA, которые повышают эффективность компаний и сопровождаем клиентов на всех этапах."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="ts-page ts-subpage ts-about-page">
+    <header class="ts-subheader" data-animate="hero">
+        <div class="ts-subheader__nav">
+            <div class="ts-container">
+                <nav class="ts-nav" aria-label="Главная навигация">
+                    <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
+                    <input id="ts-nav-toggle" class="ts-nav__checkbox" type="checkbox" aria-hidden="true" />
+                    <label for="ts-nav-toggle" class="ts-nav__toggle" aria-label="Открыть меню">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </label>
+                    <ul class="ts-nav__links">
+                        <li><a href="index.html#ts-services">Услуги</a></li>
+                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                        <li><a href="o-nas.html" aria-current="page">О нас</a></li>
+                        <li><a href="index.html#ts-pricing">Цены</a></li>
+                        <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="#ts-contact">Контакты</a></li>
+                    </ul>
+                    <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
+                </nav>
+            </div>
+        </div>
+        <div class="ts-subheader__intro" data-animate="fade-up">
+            <div class="ts-container">
+                <a class="ts-subheader__back" href="index.html#ts-home">← На главную</a>
+                <h1>О компании Technostation: AI-RPA</h1>
+                <p class="ts-subheader__summary">
+                    Мы автоматизируем процессы любой сложности, берём на себя рутину и помогаем командам сосредоточиться на стратегических задачах. В основе нашей работы — честность, прозрачность и ориентация на результат.
+                </p>
+            </div>
+        </div>
+        <div class="ts-subheader__scroll-hint" aria-hidden="true">
+            <span>Листайте вниз</span>
+            <span class="ts-subheader__scroll-icon"><span class="ts-subheader__scroll-dot"></span></span>
+        </div>
+    </header>
+
+    <main class="ts-subpage__main">
+        <section class="ts-overview ts-about-intro" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-grid ts-grid--overview">
+                    <div class="ts-overview__content" data-animate="fade-up">
+                        <h2>Миссия и ценности</h2>
+                        <p>
+                            Мы создаём цифровых помощников, которые повторяют действия сотрудников, снимают рутину и повышают качество работы команд. Каждый проект строится на принципах открытости и доверия, поэтому клиенты понимают, что, зачем и как мы автоматизируем.
+                        </p>
+                        <ul>
+                            <li>Инновационные подходы к роботизации без изменения существующей инфраструктуры.</li>
+                            <li>Прозрачность процессов, понятные этапы и контроль качества.</li>
+                            <li>Забота о командах клиентов — роботы делают рутину, сотрудники занимаются развитием бизнеса.</li>
+                        </ul>
+                    </div>
+                    <aside class="ts-about-callout" aria-label="Ключевые принципы Technostation">
+                        <h3>Фокус на долгосрочный результат</h3>
+                        <p>
+                            Мы внедряем решения, которые работают надёжно и масштабируются вместе с бизнесом. Для каждого клиента собираем оптимальную команду экспертов и сопровождаем проект до достижения измеримых показателей эффективности.
+                        </p>
+                        <ul class="ts-about-callout__list">
+                            <li>Роботизация процессов любой сложности.</li>
+                            <li>Экономия времени и операционных затрат.</li>
+                            <li>Повышение вовлечённости сотрудников.</li>
+                        </ul>
+                    </aside>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-about-expertise" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-section-header ts-section-header--left" data-animate="fade-up">
+                    <h2>Опыт, подтверждённый проектами</h2>
+                </div>
+                <div class="ts-about-expertise__grid">
+                    <article class="ts-about-expertise__card" data-animate="fade-up" data-animate-delay="0.05">
+                        <h3>Международные внедрения</h3>
+                        <p>
+                            Один из крупнейших реализованных проектов охватывал поддержку процессов в 24 странах. Мы учли особенности локальных рынков, различия в регламентах и языках, чтобы роботы работали безупречно и соответствовали требованиям каждого региона.
+                        </p>
+                    </article>
+                    <article class="ts-about-expertise__card" data-animate="fade-up" data-animate-delay="0.1">
+                        <h3>Глубокая экспертиза команды</h3>
+                        <p>
+                            Наши аналитики, архитекторы и разработчики работают как единая команда: от исследования процессов до внедрения и поддержки. Такой подход помогает предложить масштабируемые решения, которые развиваются вместе с бизнесом клиента.
+                        </p>
+                    </article>
+                    <article class="ts-about-expertise__card" data-animate="fade-up" data-animate-delay="0.15">
+                        <h3>Постоянное улучшение</h3>
+                        <p>
+                            Мы анализируем результаты каждого внедрения, собираем обратную связь и дополняем роботов новыми сценариями. Это позволяет повышать производительность, снижать затраты и сохранять устойчивость решений на долгой дистанции.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-metrics ts-about-metrics" aria-label="Ключевые показатели" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-metrics__wrapper">
+                    <div class="ts-metrics__visual" aria-hidden="true" data-animate="float">
+                        <img src="assets/images/robot-mascot.svg" alt="Цифровой помощник Technostation" />
+                        <div class="ts-metrics__glow"></div>
+                    </div>
+                    <div class="ts-metrics__stats">
+                        <article data-animate="counter" data-animate-delay="0">
+                            <h3><span class="ts-counter" data-counter-target="9" data-counter-suffix="+">0</span></h3>
+                            <p>лет опыта команды</p>
+                        </article>
+                        <article data-animate="counter" data-animate-delay="0.1">
+                            <h3><span class="ts-counter" data-counter-target="223" data-counter-suffix="+">0</span></h3>
+                            <p>реализованных проектов</p>
+                        </article>
+                        <article data-animate="counter" data-animate-delay="0.2">
+                            <h3><span class="ts-counter" data-counter-target="28" data-counter-suffix="+">0</span></h3>
+                            <p>долгосрочных клиентов</p>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-about-competencies" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-section-header ts-section-header--left" data-animate="fade-up">
+                    <h2>Наша экспертиза в цифрах</h2>
+                </div>
+                <ul class="ts-competency-list">
+                    <li class="ts-competency-item" style="--progress: 95%">
+                        <div class="ts-competency-item__header"><span>Масштабируемые RPA-решения</span><strong>95%</strong></div>
+                        <div class="ts-competency-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="95">
+                            <span class="ts-competency-fill"></span>
+                        </div>
+                    </li>
+                    <li class="ts-competency-item" style="--progress: 90%">
+                        <div class="ts-competency-item__header"><span>Технологический консалтинг по RPA</span><strong>90%</strong></div>
+                        <div class="ts-competency-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="90">
+                            <span class="ts-competency-fill"></span>
+                        </div>
+                    </li>
+                    <li class="ts-competency-item" style="--progress: 90%">
+                        <div class="ts-competency-item__header"><span>Поддержка и сопровождение решений</span><strong>90%</strong></div>
+                        <div class="ts-competency-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="90">
+                            <span class="ts-competency-fill"></span>
+                        </div>
+                    </li>
+                    <li class="ts-competency-item" style="--progress: 90%">
+                        <div class="ts-competency-item__header"><span>Роботизация сложных процессов</span><strong>90%</strong></div>
+                        <div class="ts-competency-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="90">
+                            <span class="ts-competency-fill"></span>
+                        </div>
+                    </li>
+                    <li class="ts-competency-item" style="--progress: 85%">
+                        <div class="ts-competency-item__header"><span>Интеграция с ERP, CRM и внутренними системами</span><strong>85%</strong></div>
+                        <div class="ts-competency-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="85">
+                            <span class="ts-competency-fill"></span>
+                        </div>
+                    </li>
+                    <li class="ts-competency-item" style="--progress: 80%">
+                        <div class="ts-competency-item__header"><span>Оптимизация бизнес-процессов</span><strong>80%</strong></div>
+                        <div class="ts-competency-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="80">
+                            <span class="ts-competency-fill"></span>
+                        </div>
+                    </li>
+                    <li class="ts-competency-item" style="--progress: 95%">
+                        <div class="ts-competency-item__header"><span>Информационная безопасность и конфиденциальность данных</span><strong>95%</strong></div>
+                        <div class="ts-competency-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="95">
+                            <span class="ts-competency-fill"></span>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="ts-about-accreditation" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-about-accreditation__grid">
+                    <div class="ts-about-accreditation__content ts-richtext" data-animate="fade-up">
+                        <h2>Официально аккредитованная IT-компания</h2>
+                        <p>
+                            ООО «Технологический портал Техностанция» включено в реестр аккредитованных IT-организаций Министерства цифрового развития России. Мы подтверждаем соответствие высоким стандартам отрасли и создаём решения, которые отвечают требованиям безопасности и надёжности.
+                        </p>
+                        <ul>
+                            <li>Основной вид деятельности по ОКВЭД — 62.01 «Разработка компьютерного программного обеспечения».</li>
+                            <li>Номер в реестре аккредитованных организаций: 65513.</li>
+                            <li>Номер решения о государственной аккредитации: АО-20241115-21414046354-3.</li>
+                            <li>Специализируемся на роботизации бизнес-процессов (RPA) для компаний любого масштаба.</li>
+                        </ul>
+                    </div>
+                    <div class="ts-about-accreditation__side" data-animate="fade-up" data-animate-delay="0.1">
+                        <figure class="ts-about-accreditation__badge">
+                            <img src="assets/images/accreditation-badge.svg" alt="Свидетельство аккредитации Technostation" />
+                            <figcaption>Аккредитация Минцифры России</figcaption>
+                        </figure>
+                        <div class="ts-about-partner-card">
+                            <img src="assets/images/partner-sls.svg" alt="Логотип официального партнёра SLS" />
+                            <p>Technostation — официальный партнёр SLS. Мы интегрируем решения партнёра и поддерживаем клиентов в совместных проектах.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-team" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-section-header" data-animate="fade-up">
+                    <h2>Команда экспертов</h2>
+                </div>
+                <div class="ts-grid ts-grid--team">
+                    <article class="ts-team-card" data-animate="fade-up" data-animate-delay="0">
+                        <img src="assets/images/team-yaroslav.svg" alt="Ярослав — CEO Technostation" />
+                        <h3>Ярослав</h3>
+                        <p>CEO</p>
+                    </article>
+                    <article class="ts-team-card" data-animate="fade-up" data-animate-delay="0.05">
+                        <img src="assets/images/team-andrey.svg" alt="Андрей — руководитель проектов по AI RPA" />
+                        <h3>Андрей</h3>
+                        <p>Руководитель проектов по AI RPA и бизнес-аналитике</p>
+                    </article>
+                    <article class="ts-team-card" data-animate="fade-up" data-animate-delay="0.1">
+                        <img src="assets/images/team-anastasiya.svg" alt="Анастасия — менеджер по работе с клиентами" />
+                        <h3>Анастасия</h3>
+                        <p>Менеджер по работе с клиентами</p>
+                    </article>
+                    <article class="ts-team-card" data-animate="fade-up" data-animate-delay="0.15">
+                        <img src="assets/images/team-andrey-dev.svg" alt="Андрей — разработчик Technostation" />
+                        <h3>Андрей</h3>
+                        <p>Разработчик</p>
+                    </article>
+                    <article class="ts-team-card" data-animate="fade-up" data-animate-delay="0.2">
+                        <img src="assets/images/team-nikita.svg" alt="Никита — разработчик Technostation" />
+                        <h3>Никита</h3>
+                        <p>Разработчик</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-contact" id="ts-contact" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-section-header" data-animate="fade-up">
+                    <h2>Связаться с нами</h2>
+                </div>
+                <form class="ts-contact__form" action="#" method="post" data-animate="fade-up" data-animate-delay="0.1">
+                    <div class="ts-form-grid">
+                        <label class="ts-form-field">
+                            <span class="ts-form-label">Имя*</span>
+                            <input type="text" name="name" placeholder="Имя*" required />
+                        </label>
+                        <label class="ts-form-field">
+                            <span class="ts-form-label">Телефон*</span>
+                            <input type="tel" name="phone" placeholder="Телефон*" required />
+                        </label>
+                        <label class="ts-form-field">
+                            <span class="ts-form-label">E-mail</span>
+                            <input type="email" name="email" placeholder="E-mail" />
+                        </label>
+                        <label class="ts-form-field ts-form-field--full">
+                            <span class="ts-form-label">Сообщение</span>
+                            <textarea name="message" rows="4" placeholder="Сообщение"></textarea>
+                        </label>
+                        <label class="ts-form-checkbox ts-form-field--full">
+                            <input type="checkbox" required />
+                            <span class="ts-checkbox"></span>
+                            <span>Даю согласие на обработку персональных данных в соответствии с Политикой конфиденциальности и Согласием на обработку персональных данных.</span>
+                        </label>
+                    </div>
+                    <button type="submit" class="ts-button ts-button--primary">Отправить</button>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="ts-footer">
+        <div class="ts-container ts-grid ts-grid--footer">
+            <div>
+                <h2 class="ts-footer__logo">Technostation: AI-RPA</h2>
+                <p>Наши виртуальные роботы подстраиваются под ваши процессы, устраняя рутину и эмулируя действия сотрудников. Ваша система остается неизменной, а бизнес фокусируется на росте и увеличении эффективности.</p>
+                <div class="ts-footer__socials">
+                    <a href="https://wa.me/79296159054/" aria-label="WhatsApp"><span>WhatsApp</span></a>
+                    <a href="https://t.me/Yaroslav_TechnoStation" aria-label="Telegram"><span>Telegram</span></a>
+                </div>
+            </div>
+            <div>
+                <h3>Навигация</h3>
+                <ul>
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="#ts-contact">Контакты</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3>Материалы</h3>
+                <ul>
+                    <li><a href="Полезные материалы по роботизации процессов.html">Все статьи</a></li>
+                    <li><a href="Преимущества RPA для малого и среднего бизнеса.html">Преимущества RPA</a></li>
+                    <li><a href="Примеры успешных внедрений в малом, среднем и крупном бизнесе.html">Кейсы внедрений</a></li>
+                    <li><a href="Стек используемых технологий и языки программирования в наших RPA-решениях.html">Стек технологий</a></li>
+                </ul>
+            </div>
+            <div class="ts-footer__contact">
+                <h3>Контакты</h3>
+                <p><strong>Телефон:</strong> <a href="tel:+79296159054">+7(929)615-90-54</a></p>
+                <p><strong>E-mail:</strong> <a href="mailto:info@ai-rpa.ru">info@ai-rpa.ru</a></p>
+                <p><strong>Адрес:</strong> 125167, Москва, пр-кт Ленинградский, д. 47, стр. 2, помещение 28А</p>
+                <p><strong>Время работы:</strong> пн-пт: 9.00 - 18.00</p>
+            </div>
+        </div>
+        <div class="ts-footer__bottom">
+            <p>© 2025 Technostation: AI-RPA</p>
+            <p>Политика конфиденциальности предоставляется по запросу.</p>
+        </div>
+    </footer>
+
+    <a class="ts-floating-cta" href="#ts-contact">Связаться с нами</a>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/oczenka-proekta.html
+++ b/oczenka-proekta.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -159,6 +160,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/pervyie-shagi.html
+++ b/pervyie-shagi.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -162,6 +163,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/progress.html
+++ b/progress.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -163,6 +164,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/xochu-poprobovat.html
+++ b/xochu-poprobovat.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -161,6 +162,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/Анализ текущих тенденций и прогноз развития роботизации бизнес-процессов в мире.html
+++ b/Анализ текущих тенденций и прогноз развития роботизации бизнес-процессов в мире.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -220,6 +221,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/Полезные материалы по роботизации процессов.html
+++ b/Полезные материалы по роботизации процессов.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -169,6 +170,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/Преимущества RPA для малого и среднего бизнеса.html
+++ b/Преимущества RPA для малого и среднего бизнеса.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -480,6 +481,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/Применение RPA в российских компаниях и государственном секторе.html
+++ b/Применение RPA в российских компаниях и государственном секторе.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -286,6 +287,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/Примеры успешных внедрений в малом, среднем и крупном бизнесе.html
+++ b/Примеры успешных внедрений в малом, среднем и крупном бизнесе.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -376,6 +377,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/Советы по успешному внедрению RPA в вашу компанию.html
+++ b/Советы по успешному внедрению RPA в вашу компанию.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -294,6 +295,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/Стек используемых технологий и языки программирования в наших RPA-решениях.html
+++ b/Стек используемых технологий и языки программирования в наших RPA-решениях.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -539,6 +540,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>

--- a/Тенденции и будущее RPA_ чего ожидать_.html
+++ b/Тенденции и будущее RPA_ чего ожидать_.html
@@ -25,6 +25,7 @@
                     <ul class="ts-nav__links">
                         <li><a href="index.html#ts-services">Услуги</a></li>
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
@@ -242,6 +243,7 @@
                 <ul>
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>


### PR DESCRIPTION
## Summary
- create a new "О нас" page that mirrors the legacy content in the refreshed site style, including mission, experience, metrics, competencies, accreditation, partners, and team sections
- add dedicated styles and assets for the about page, including accreditation and partner artwork, and competence progress visuals
- update global navigation and footer menus to include the new page across all sections of the site

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e2e08cd5e083308ca5e4c0010213ef