### PR TITLE
Add partner programs pages and navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="#ts-pricing">Цены</a></li>
                     <li><a href="#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="#ts-contact">Контакты</a></li>
                     <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
                 </ul>
@@ -1186,6 +1187,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/individualnyij-podxod.html
+++ b/individualnyij-podxod.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -166,6 +167,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/kalkulyator-effektivnosti.html
+++ b/kalkulyator-effektivnosti.html
@@ -27,6 +27,7 @@
                         <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>

--- a/maksimum.html
+++ b/maksimum.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -166,6 +167,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/o-nas.html
+++ b/o-nas.html
@@ -31,6 +31,7 @@
                         <li><a href="o-nas.html" aria-current="page">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>

--- a/oczenka-proekta.html
+++ b/oczenka-proekta.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -163,6 +164,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/partner-programmy.html
+++ b/partner-programmy.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Партнерские программы — Technostation: AI-RPA</title>
+    <meta
+        name="description"
+        content="Партнерские программы ООО &quot;Техностанция&quot; — реферальная и агентская модели сотрудничества с прозрачными условиями и поддержкой в оформлении документов."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="ts-page ts-subpage">
+    <header class="ts-subheader" data-animate="hero">
+        <div class="ts-subheader__nav">
+            <div class="ts-container">
+                <nav class="ts-nav" aria-label="Главная навигация">
+                    <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
+                    <input id="ts-nav-toggle" class="ts-nav__checkbox" type="checkbox" aria-hidden="true" />
+                    <label for="ts-nav-toggle" class="ts-nav__toggle" aria-label="Открыть меню">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </label>
+                    <ul class="ts-nav__links">
+                        <li><a href="index.html#ts-services">Услуги</a></li>
+                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                        <li><a href="o-nas.html">О нас</a></li>
+                        <li><a href="index.html#ts-pricing">Цены</a></li>
+                        <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html" aria-current="page">Партнерские программы</a></li>
+                        <li><a href="#ts-contact">Контакты</a></li>
+                    </ul>
+                    <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
+                </nav>
+            </div>
+        </div>
+        <div class="ts-subheader__intro" data-animate="fade-up">
+            <div class="ts-container">
+                <a class="ts-subheader__back" href="index.html#ts-home">← На главную</a>
+                <h1>Партнерские программы</h1>
+                <p class="ts-subheader__summary">
+                    Получайте вознаграждение за привлечение новых клиентов в рамках реферальной или агентской программы.
+                    Мы обеспечиваем прозрачность расчетов, юридическую поддержку и подробные консультации для всех участников.
+                </p>
+            </div>
+        </div>
+        <div class="ts-subheader__scroll-hint" aria-hidden="true">
+            <span>Листайте вниз</span>
+            <span class="ts-subheader__scroll-icon"><span class="ts-subheader__scroll-dot"></span></span>
+        </div>
+    </header>
+
+    <main class="ts-subpage__main">
+        <section class="ts-partner-overview" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-richtext" data-animate="fade-up">
+                    <h2>Партнёрские программы ООО &laquo;Техностанция&raquo;</h2>
+                    <p>
+                        Мы предлагаем реферальную и агентскую программы для физических и юридических лиц, которые позволяют получать
+                        вознаграждение за привлечение новых клиентов. Все программы разработаны с учётом требований российского законодательства и
+                        ориентированы на прозрачное и удобное взаимодействие.
+                    </p>
+                    <p>
+                        <a class="ts-button ts-button--primary" href="referalnyij-i-agentskij-dogovory.html">Реферальный и агентский договоры</a>
+                    </p>
+                    <h3>Основные условия программы</h3>
+                    <p>
+                        <strong>Прозрачность и законность.</strong> Все операции проводятся исключительно по безналичному расчёту и строго в рамках российского законодательства.
+                        Налоги на полученные реферальные выплаты оплачиваются лицом, получающим вознаграждение (например, самозанятый обязан самостоятельно уплачивать налог с дохода).
+                        Мы предоставляем все необходимые документы для налоговой отчётности и всегда готовы проконсультировать по этим вопросам.
+                    </p>
+                    <p>
+                        <strong>Период выплат.</strong> Выплаты начисляются с каждого поступления средств от новой компании в течение первого года сотрудничества с ней.
+                        Это означает, что вы будете получать свой % с каждого платежа от привлечённой компании в течение 12 месяцев с момента начала сотрудничества с привлечённой компанией.
+                    </p>
+                    <p>
+                        <strong>Заключение договора.</strong> Для участия в программе требуется заключение реферального или агентского договора.
+                        Например, возможно заключение агентского договора, по которому вы будете выступать как агент, привлекающий клиентов от своего имени, с правом на получение агентского вознаграждения.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-partner-faq" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-section-header ts-section-header--left" data-animate="fade-up">
+                    <h2>Часто задаваемые вопросы (FAQ)</h2>
+                </div>
+                <div class="ts-richtext" data-animate="fade-up" data-animate-delay="0.1">
+                    <h3>Вопрос: Кто может участвовать в программе?</h3>
+                    <p>Ответ: Программа доступна как для физических лиц (включая самозанятых), так и для юридических лиц.</p>
+
+                    <h3>Вопрос: Как производится выплата?</h3>
+                    <p>
+                        Ответ: Выплата вознаграждения производится на ваш расчётный счёт в безналичной форме. Налоги на полученные суммы оплачивает
+                        реферал/агент в соответствии с законодательством.
+                    </p>
+
+                    <h3>Вопрос: Как долго действуют реферальные/агентские выплаты?</h3>
+                    <p>
+                        Ответ: Вы будете получать свой % с каждого платежа, поступающего от привлечённой Вами компании, в течение первого года сотрудничества с ней.
+                    </p>
+
+                    <h3>Вопрос: Какие документы необходимы для участия?</h3>
+                    <p>
+                        Ответ: Для физических лиц (самозанятых) – паспорт. Для юридических лиц требуется стандартный пакет документов.
+                    </p>
+
+                    <h3>Вопрос: Что делать, если я самозанятый?</h3>
+                    <p>
+                        Ответ: Самозанятые могут участвовать в реферальной программе, зарегистрировавшись в системе &laquo;Мой налог&raquo; и самостоятельно уплачивая налог с дохода.
+                        Мы поможем с оформлением нужных документов.
+                    </p>
+
+                    <h3>Вопрос: Как будет выплачиваться вознаграждение, если привлечение одного контрагента произошло через нескольких участников?</h3>
+                    <p>
+                        Ответ: Вознаграждение выплачивается тому участнику, с которым заключён договор. Все вопросы о распределении вознаграждения между несколькими участниками
+                        решаются самими участниками. Мы не вмешиваемся в этот процесс и не выплачиваем двойное вознаграждение за одного контрагента.
+                    </p>
+
+                    <h3>Вопрос: Мне интересно участвовать в программе, но я ничего не понимаю в RPA. Как быть?</h3>
+                    <p>
+                        Ответ: Мы проведём краткое обучение основам RPA и ответим на любые вопросы, чтобы помочь Вам понять основные принципы работы и взаимодействия с технологиями роботизации.
+                        Это поможет Вам эффективно участвовать в программе, даже если у вас нет технических знаний.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-partner-start" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-section-header ts-section-header--left" data-animate="fade-up">
+                    <h2>Как начать?</h2>
+                </div>
+                <div class="ts-richtext" data-animate="fade-up" data-animate-delay="0.1">
+                    <ol>
+                        <li>Оставьте заявку на участие в программе через нашу форму обратной связи или любым другим удобным способом.</li>
+                        <li>Заключите договор с нами и начните привлекать клиентов.</li>
+                        <li>Получайте вознаграждение с каждого платежа в течение первого года сотрудничества с привлечённой компанией.</li>
+                    </ol>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-contact" id="ts-contact" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-section-header" data-animate="fade-up">
+                    <h2>Связаться с нами</h2>
+                    <p>Расскажите о своей задаче, и мы подберём оптимальное решение.</p>
+                </div>
+                <div class="ts-contact__layout">
+                    <div class="ts-contact__info" data-animate="fade-up" data-animate-delay="0.05">
+                        <div class="ts-contact__card">
+                            <h3>Контакты</h3>
+                            <ul>
+                                <li><strong>Телефон:</strong> <a href="tel:+79296159054">+7(929)615-90-54</a></li>
+                                <li><strong>E-mail:</strong> <a href="mailto:info@ai-rpa.ru">info@ai-rpa.ru</a></li>
+                                <li><strong>Адрес:</strong> 125167, Москва, пр-кт Ленинградский, д. 47, стр. 2, помещение 28А</li>
+                                <li><strong>Время работы:</strong> пн-пт: 9.00 - 18.00</li>
+                            </ul>
+                        </div>
+                        <div class="ts-contact__card">
+                            <h3>Как мы работаем</h3>
+                            <ol>
+                                <li>Обсуждаем задачу и цели.</li>
+                                <li>Проводим экспресс-аудит процессов.</li>
+                                <li>Подбираем оптимальное решение и согласовываем этапы.</li>
+                            </ol>
+                        </div>
+                    </div>
+                    <form class="ts-contact__form" data-animate="fade-up" data-animate-delay="0.1">
+                        <div class="ts-form__group">
+                            <label for="partner-name">Имя</label>
+                            <input id="partner-name" type="text" name="name" placeholder="Введите ваше имя" required />
+                        </div>
+                        <div class="ts-form__group">
+                            <label for="partner-email">E-mail</label>
+                            <input id="partner-email" type="email" name="email" placeholder="Введите ваш E-mail" required />
+                        </div>
+                        <div class="ts-form__group">
+                            <label for="partner-phone">Телефон</label>
+                            <input id="partner-phone" type="tel" name="phone" placeholder="Введите ваш телефон" required />
+                        </div>
+                        <div class="ts-form__group">
+                            <label for="partner-message">Расскажите о задаче</label>
+                            <textarea id="partner-message" name="message" rows="4" placeholder="Опишите, как вы хотите сотрудничать"></textarea>
+                        </div>
+                        <button class="ts-button ts-button--primary" type="submit">Отправить заявку</button>
+                        <p class="ts-form__note">Нажимая кнопку, вы соглашаетесь с обработкой персональных данных.</p>
+                    </form>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="ts-footer">
+        <div class="ts-container">
+            <div>
+                <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
+                <p>Решения по роботизации процессов, которые помогают бизнесу расти быстрее.</p>
+            </div>
+            <div>
+                <h3>Навигация</h3>
+                <ul>
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
+                    <li><a href="index.html#ts-contact">Контакты</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3>Материалы</h3>
+                <ul>
+                    <li><a href="Полезные материалы по роботизации процессов.html">Все статьи</a></li>
+                    <li><a href="Преимущества RPA для малого и среднего бизнеса.html">Преимущества RPA</a></li>
+                    <li><a href="Примеры успешных внедрений в малом, среднем и крупном бизнесе.html">Кейсы внедрений</a></li>
+                    <li><a href="Стек используемых технологий и языки программирования в наших RPA-решениях.html">Стек технологий</a></li>
+                </ul>
+            </div>
+            <div class="ts-footer__contact">
+                <h3>Контакты</h3>
+                <p><strong>Телефон:</strong> <a href="tel:+79296159054">+7(929)615-90-54</a></p>
+                <p><strong>E-mail:</strong> <a href="mailto:info@ai-rpa.ru">info@ai-rpa.ru</a></p>
+                <p><strong>Адрес:</strong> 125167, Москва, пр-кт Ленинградский, д. 47, стр. 2, помещение 28А</p>
+                <p><strong>Время работы:</strong> пн-пт: 9.00 - 18.00</p>
+            </div>
+        </div>
+        <div class="ts-footer__bottom">
+            <p>© 2025 Technostation: AI-RPA</p>
+            <p>Политика конфиденциальности предоставляется по запросу.</p>
+        </div>
+    </footer>
+
+    <a class="ts-floating-cta" href="#ts-contact">Связаться с нами</a>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/pervyie-shagi.html
+++ b/pervyie-shagi.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -166,6 +167,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/primery-rabot-robotov.html
+++ b/primery-rabot-robotov.html
@@ -30,6 +30,7 @@
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                     <li><a href="primery-rabot-robotov.html" aria-current="page">Примеры роботов</a></li>
                 </ul>

--- a/progress.html
+++ b/progress.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -167,6 +168,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/referalnyij-i-agentskij-dogovory.html
+++ b/referalnyij-i-agentskij-dogovory.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Реферальный и агентский договоры — Technostation: AI-RPA</title>
+    <meta
+        name="description"
+        content="Реферальный и агентский договоры Technostation: сравнение условий сотрудничества, уровней ответственности и вариантов вознаграждения."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="ts-page ts-subpage">
+    <header class="ts-subheader" data-animate="hero">
+        <div class="ts-subheader__nav">
+            <div class="ts-container">
+                <nav class="ts-nav" aria-label="Главная навигация">
+                    <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
+                    <input id="ts-nav-toggle" class="ts-nav__checkbox" type="checkbox" aria-hidden="true" />
+                    <label for="ts-nav-toggle" class="ts-nav__toggle" aria-label="Открыть меню">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </label>
+                    <ul class="ts-nav__links">
+                        <li><a href="index.html#ts-services">Услуги</a></li>
+                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                        <li><a href="o-nas.html">О нас</a></li>
+                        <li><a href="index.html#ts-pricing">Цены</a></li>
+                        <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html" aria-current="page">Партнерские программы</a></li>
+                        <li><a href="#ts-contact">Контакты</a></li>
+                    </ul>
+                    <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
+                </nav>
+            </div>
+        </div>
+        <div class="ts-subheader__intro" data-animate="fade-up">
+            <div class="ts-container">
+                <a class="ts-subheader__back" href="partner-programmy.html">← Вернуться к программам</a>
+                <h1>Реферальный и агентский договоры</h1>
+                <p class="ts-subheader__summary">
+                    Разбираем разницу между реферальным и агентским сотрудничеством, чтобы вы могли выбрать подходящую модель взаимодействия с Technostation.
+                </p>
+            </div>
+        </div>
+        <div class="ts-subheader__scroll-hint" aria-hidden="true">
+            <span>Листайте вниз</span>
+            <span class="ts-subheader__scroll-icon"><span class="ts-subheader__scroll-dot"></span></span>
+        </div>
+    </header>
+
+    <main class="ts-subpage__main">
+        <section class="ts-partner-contracts" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-richtext" data-animate="fade-up">
+                    <h2>Реферальный и агентский договоры</h2>
+                    <p>
+                        Разница между реферальным и агентским договорами заключается в правовом статусе, характере обязательств сторон и уровне вовлеченности в процесс привлечения клиентов.
+                        Вот основные отличия:
+                    </p>
+
+                    <h3>1. Степень участия</h3>
+                    <p><strong>Реферальный договор:</strong></p>
+                    <p>
+                        Реферал просто рекомендует клиентов или направляет их к компании. Он не участвует в процессе заключения сделки или выполнении обязательств.
+                        Его задача ограничивается привлечением новых клиентов, за что он получает вознаграждение. Реферал не только рекомендует клиентов, но и несет ответственность за предоставление корректной информации
+                        о потенциальных клиентах, а также разрешением (достаточно в устной форме) от контрагента на передачу нам личных данных (телефон, e-mail, ФИО и др).
+                        Влияние реферала на отношения между компанией и привлечённым клиентом минимально. Обычно, после рекомендации или направления клиента, реферал больше не участвует в процессе.
+                    </p>
+                    <p><strong>Агентский договор:</strong></p>
+                    <p>
+                        Агент действует от имени компании (Принципала) и имеет право заключать сделки и взаимодействовать с клиентами от лица компании. Он может вести переговоры, продвигать услуги и продукты,
+                        иногда даже заключать договоры от имени Принципала.
+                        Агент обычно имеет более широкие полномочия, он становится своего рода посредником между клиентом и компанией, активно участвует в процессе сотрудничества и может представлять интересы компании в сделках.
+                    </p>
+
+                    <h3>2. Объём ответственности</h3>
+                    <p><strong>Реферальный договор:</strong></p>
+                    <p>
+                        Ответственность реферала ограничена рекомендацией. Он не несёт обязательств по заключению сделок, качеству услуг или соблюдению условий договора между компанией и привлечённым клиентом.
+                    </p>
+                    <p><strong>Агентский договор:</strong></p>
+                    <p>
+                        Агент несёт гораздо большую ответственность за свои действия. Он обязан выполнять поручения Принципала, действовать добросовестно, заключать сделки, поддерживать деловые отношения с клиентами.
+                        Агент отвечает за корректность заключённых сделок и выполнение условий договора.
+                    </p>
+
+                    <h3>3. Статус и вознаграждение</h3>
+                    <p><strong>Реферальный договор:</strong></p>
+                    <p>
+                        Реферальная программа чаще используется для привлечения клиентов через рекомендации, вознаграждение реферала фиксировано в размере 5%.
+                        Реферал получает вознаграждение только в том случае, если привлеченный клиент заключает сделку и выполняет свои финансовые обязательства перед компанией.
+                    </p>
+                    <p><strong>Агентский договор:</strong></p>
+                    <p>
+                        Агент действует на более формальных условиях и получает более высокое вознаграждение в зависимости от условий договора и взятых на себя обязательств.
+                    </p>
+
+                    <h3>4. Правовой статус</h3>
+                    <p><strong>Реферальный договор:</strong></p>
+                    <p>
+                        Более простая и неформальная форма соглашения. Он ограничен рекомендациями и не требует строгих юридических обязательств.
+                    </p>
+                    <p><strong>Агентский договор:</strong></p>
+                    <p>
+                        Более формальный документ, подразумевающий глубокое вовлечение агента в бизнес-коммуникации. Агент действует в рамках агентского законодательства,
+                        и договор регулируется нормами о представительстве и поручении.
+                    </p>
+
+                    <h3>Когда лучше использовать реферальный договор?</h3>
+                    <ul>
+                        <li>Когда цель — простое привлечение клиентов по рекомендациям.</li>
+                        <li>Когда не готовы заключать сделки от имени компании.</li>
+                        <li>Когда не хотите глубокого вовлечения в процессы продаж и сопровождения клиентов.</li>
+                    </ul>
+
+                    <h3>Когда лучше использовать агентский договор?</h3>
+                    <ul>
+                        <li>Когда готовы активно продвигать услуги и продукты.</li>
+                        <li>Когда требуется полномочие на заключение сделок от имени компании.</li>
+                        <li>Когда агент должен вести переговоры и представлять интересы компании в процессе продаж.</li>
+                        <li>Когда есть заинтересованность в более высоком вознаграждении.</li>
+                    </ul>
+
+                    <p>
+                        Таким образом, выбор между реферальным и агентским договором зависит от уровня вовлечённости и ответственности, которые вы готовы на себя взять,
+                        а также от того, какой уровень вознаграждения хотите получать.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section class="ts-contact" id="ts-contact" data-animate="section">
+            <div class="ts-container">
+                <div class="ts-section-header" data-animate="fade-up">
+                    <h2>Связаться с нами</h2>
+                    <p>Расскажите о своей задаче, и мы подберём оптимальное решение.</p>
+                </div>
+                <div class="ts-contact__layout">
+                    <div class="ts-contact__info" data-animate="fade-up" data-animate-delay="0.05">
+                        <div class="ts-contact__card">
+                            <h3>Контакты</h3>
+                            <ul>
+                                <li><strong>Телефон:</strong> <a href="tel:+79296159054">+7(929)615-90-54</a></li>
+                                <li><strong>E-mail:</strong> <a href="mailto:info@ai-rpa.ru">info@ai-rpa.ru</a></li>
+                                <li><strong>Адрес:</strong> 125167, Москва, пр-кт Ленинградский, д. 47, стр. 2, помещение 28А</li>
+                                <li><strong>Время работы:</strong> пн-пт: 9.00 - 18.00</li>
+                            </ul>
+                        </div>
+                        <div class="ts-contact__card">
+                            <h3>Как мы работаем</h3>
+                            <ol>
+                                <li>Обсуждаем задачу и цели.</li>
+                                <li>Проводим экспресс-аудит процессов.</li>
+                                <li>Подбираем оптимальное решение и согласовываем этапы.</li>
+                            </ol>
+                        </div>
+                    </div>
+                    <form class="ts-contact__form" data-animate="fade-up" data-animate-delay="0.1">
+                        <div class="ts-form__group">
+                            <label for="contract-name">Имя</label>
+                            <input id="contract-name" type="text" name="name" placeholder="Введите ваше имя" required />
+                        </div>
+                        <div class="ts-form__group">
+                            <label for="contract-email">E-mail</label>
+                            <input id="contract-email" type="email" name="email" placeholder="Введите ваш E-mail" required />
+                        </div>
+                        <div class="ts-form__group">
+                            <label for="contract-phone">Телефон</label>
+                            <input id="contract-phone" type="tel" name="phone" placeholder="Введите ваш телефон" required />
+                        </div>
+                        <div class="ts-form__group">
+                            <label for="contract-message">Расскажите о задаче</label>
+                            <textarea id="contract-message" name="message" rows="4" placeholder="Опишите, как вы хотите сотрудничать"></textarea>
+                        </div>
+                        <button class="ts-button ts-button--primary" type="submit">Отправить заявку</button>
+                        <p class="ts-form__note">Нажимая кнопку, вы соглашаетесь с обработкой персональных данных.</p>
+                    </form>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="ts-footer">
+        <div class="ts-container">
+            <div>
+                <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
+                <p>Решения по роботизации процессов, которые помогают бизнесу расти быстрее.</p>
+            </div>
+            <div>
+                <h3>Навигация</h3>
+                <ul>
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
+                    <li><a href="index.html#ts-contact">Контакты</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3>Материалы</h3>
+                <ul>
+                    <li><a href="Полезные материалы по роботизации процессов.html">Все статьи</a></li>
+                    <li><a href="Преимущества RPA для малого и среднего бизнеса.html">Преимущества RPA</a></li>
+                    <li><a href="Примеры успешных внедрений в малом, среднем и крупном бизнесе.html">Кейсы внедрений</a></li>
+                    <li><a href="Стек используемых технологий и языки программирования в наших RPA-решениях.html">Стек технологий</a></li>
+                </ul>
+            </div>
+            <div class="ts-footer__contact">
+                <h3>Контакты</h3>
+                <p><strong>Телефон:</strong> <a href="tel:+79296159054">+7(929)615-90-54</a></p>
+                <p><strong>E-mail:</strong> <a href="mailto:info@ai-rpa.ru">info@ai-rpa.ru</a></p>
+                <p><strong>Адрес:</strong> 125167, Москва, пр-кт Ленинградский, д. 47, стр. 2, помещение 28А</p>
+                <p><strong>Время работы:</strong> пн-пт: 9.00 - 18.00</p>
+            </div>
+        </div>
+        <div class="ts-footer__bottom">
+            <p>© 2025 Technostation: AI-RPA</p>
+            <p>Политика конфиденциальности предоставляется по запросу.</p>
+        </div>
+    </footer>
+
+    <a class="ts-floating-cta" href="#ts-contact">Связаться с нами</a>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/xochu-poprobovat.html
+++ b/xochu-poprobovat.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -165,6 +166,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/Анализ текущих тенденций и прогноз развития роботизации бизнес-процессов в мире.html
+++ b/Анализ текущих тенденций и прогноз развития роботизации бизнес-процессов в мире.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -224,6 +225,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/Полезные материалы по роботизации процессов.html
+++ b/Полезные материалы по роботизации процессов.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -173,6 +174,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/Преимущества RPA для малого и среднего бизнеса.html
+++ b/Преимущества RPA для малого и среднего бизнеса.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -484,6 +485,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/Применение RPA в российских компаниях и государственном секторе.html
+++ b/Применение RPA в российских компаниях и государственном секторе.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -290,6 +291,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/Примеры успешных внедрений в малом, среднем и крупном бизнесе.html
+++ b/Примеры успешных внедрений в малом, среднем и крупном бизнесе.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -380,6 +381,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/Советы по успешному внедрению RPA в вашу компанию.html
+++ b/Советы по успешному внедрению RPA в вашу компанию.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -298,6 +299,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/Стек используемых технологий и языки программирования в наших RPA-решениях.html
+++ b/Стек используемых технологий и языки программирования в наших RPA-решениях.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -543,6 +544,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>

--- a/Тенденции и будущее RPA_ чего ожидать_.html
+++ b/Тенденции и будущее RPA_ чего ожидать_.html
@@ -28,6 +28,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                         <li><a href="index.html#ts-pricing">Цены</a></li>
                         <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="partner-programmy.html">Партнерские программы</a></li>
                         <li><a href="#ts-contact">Контакты</a></li>
                     </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
@@ -246,6 +247,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
                     <li><a href="index.html#ts-contact">Контакты</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- add a partner programs link to navigation menus and footers across the site
- create a partner programs landing page with program details, FAQ, and contact form
- add a referral vs. agency contract explanation page linked from the partner programs page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2e3be49f88330a8e985c1384cf618