### PR TITLE
Add privacy policy page and update footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1208,7 +1208,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/individualnyij-podxod.html
+++ b/individualnyij-podxod.html
@@ -188,7 +188,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/maksimum.html
+++ b/maksimum.html
@@ -188,7 +188,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/o-nas.html
+++ b/o-nas.html
@@ -326,7 +326,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/oczenka-proekta.html
+++ b/oczenka-proekta.html
@@ -185,7 +185,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/pervyie-shagi.html
+++ b/pervyie-shagi.html
@@ -188,7 +188,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/politika-konfidenczialnosti.html
+++ b/politika-konfidenczialnosti.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Политика конфиденциальности Technostation: AI-RPA</title>
+    <meta
+        name="description"
+        content="Политика конфиденциальности ООО 'Техностанция'. Узнайте, как мы обрабатываем и защищаем персональные данные пользователей."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="ts-page ts-subpage ts-legal-page">
+    <header class="ts-subheader" data-animate="hero">
+        <div class="ts-subheader__nav">
+            <div class="ts-container">
+                <nav class="ts-nav" aria-label="Главная навигация">
+                    <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
+                    <input id="ts-nav-toggle" class="ts-nav__checkbox" type="checkbox" aria-hidden="true" />
+                    <label for="ts-nav-toggle" class="ts-nav__toggle" aria-label="Открыть меню">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </label>
+                    <ul class="ts-nav__links">
+                        <li><a href="index.html#ts-services">Услуги</a></li>
+                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                        <li><a href="o-nas.html">О нас</a></li>
+                        <li><a href="index.html#ts-pricing">Цены</a></li>
+                        <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="#ts-contact">Контакты</a></li>
+                    </ul>
+                    <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
+                </nav>
+            </div>
+        </div>
+        <div class="ts-subheader__intro" data-animate="fade-up">
+            <div class="ts-container">
+                <a class="ts-subheader__back" href="index.html#ts-home">← На главную</a>
+                <h1>Политика конфиденциальности</h1>
+                <p class="ts-subheader__summary">
+                    Настоящая политика описывает порядок обработки и защиты персональных данных в ООО «Техностанция».
+                </p>
+            </div>
+        </div>
+        <div class="ts-subheader__scroll-hint" aria-hidden="true">
+            <span>Листайте вниз</span>
+            <span class="ts-subheader__scroll-icon"><span class="ts-subheader__scroll-dot"></span></span>
+        </div>
+    </header>
+
+    <main class="ts-subpage__main">
+        <section class="ts-legal" data-animate="section">
+            <div class="ts-container">
+                <article class="ts-legal__content" aria-label="Политика конфиденциальности ООО &quot;Техностанция&quot;">
+                    <h2>Политика конфиденциальности ООО «Техностанция»</h2>
+
+                    <h3>1. Общие положения</h3>
+                    <p><strong>1.1.</strong> Настоящая Политика определяет порядок обработки и защиты персональных данных физических лиц, работающих с ООО «Техностанция» (далее — Компания).</p>
+                    <p><strong>1.2.</strong> Цель: защита персональных данных пользователей от неправомерного доступа, раскрытия и использования.</p>
+                    <p><strong>1.3.</strong> Настоящая Политика разработана в соответствии с требованиями законодательства Российской Федерации, в том числе Федерального закона №152-ФЗ «О персональных данных».</p>
+                    <p><strong>1.4.</strong> Актуальная версия Политики доступна на сайте Компании по адресу: ai-rpa.ru/politika-konfidenczialnosti.html.</p>
+
+                    <h3>2. Сбор и обработка персональных данных</h3>
+                    <p><strong>2.1.</strong> Компания собирает и хранит только те данные, которые необходимы для предоставления услуг и взаимодействия с пользователями.</p>
+                    <p><strong>2.2.</strong> Цели обработки данных:</p>
+                    <ul>
+                        <li>предоставление консультационных и информационных услуг;</li>
+                        <li>уведомления о новых услугах и предложениях;</li>
+                        <li>ответы на запросы пользователей;</li>
+                        <li>улучшение качества услуг и разработка новых предложений.</li>
+                    </ul>
+                    <p><strong>2.3.</strong> Обработка данных основывается на принципах законности, соответствия объема целей обработки, а также добросовестности.</p>
+
+                    <h3>3. Хранение и использование персональных данных</h3>
+                    <p><strong>3.1.</strong> Персональные данные хранятся на электронных носителях и обрабатываются с использованием автоматизированных систем.</p>
+                    <p><strong>3.2.</strong> Передача персональных данных третьим лицам возможна только по законным основаниям, включая запросы госорганов и судебные решения.</p>
+
+                    <h3>4. Защита персональных данных</h3>
+                    <p><strong>4.1.</strong> Компания принимает все необходимые меры для защиты данных от неправомерного доступа, изменения, раскрытия или уничтожения.</p>
+                    <p><strong>4.2.</strong> Доступ к данным сотрудников Компании ограничен, и они обязаны соблюдать политику конфиденциальности.</p>
+
+                    <h3>5. Права субъекта персональных данных</h3>
+                    <p><strong>5.1.</strong> Пользователь имеет право на получение информации о своих данных, их корректировку или удаление в случае неполноты, устаревания или нарушения законности обработки.</p>
+                    <p><strong>5.2.</strong> Запросы по обработке данных можно направлять на электронный адрес Компании.</p>
+
+                    <h3>6. Изменение Политики конфиденциальности</h3>
+                    <p><strong>6.1.</strong> Компания может вносить изменения в Политику конфиденциальности. Новая версия вступает в силу с момента ее размещения на сайте, если иное не предусмотрено законодательством.</p>
+
+                    <p>
+                        <strong>
+                            <a href="statya-9-soglasie-na-obrabotku-pd.pdf" target="_blank" rel="noopener">
+                                Статья 9. Согласие на обработку персональных данных
+                            </a>
+                        </strong>
+                    </p>
+                    <p><strong>Дата публикации: 11.10.2024</strong></p>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="ts-footer" id="ts-contact">
+        <div class="ts-container ts-footer__grid">
+            <div>
+                <h3>О компании</h3>
+                <p>
+                    Technostation: AI-RPA — цифровая студия, которая автоматизирует бизнес-процессы с помощью роботов, сохраняя у
+                    правление за людьми.
+                </p>
+            </div>
+            <div>
+                <h3>Навигация</h3>
+                <ul>
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="#ts-contact">Контакты</a></li>
+                </ul>
+            </div>
+            <div>
+                <h3>Материалы</h3>
+                <ul>
+                    <li><a href="Полезные материалы по роботизации процессов.html">Все статьи</a></li>
+                    <li><a href="Преимущества RPA для малого и среднего бизнеса.html">Преимущества RPA</a></li>
+                    <li><a href="Примеры успешных внедрений в малом, среднем и крупном бизнесе.html">Кейсы внедрений</a></li>
+                    <li><a href="Стек используемых технологий и языки программирования в наших RPA-решениях.html">Стек технологий</a></li>
+                </ul>
+            </div>
+            <div class="ts-footer__contact">
+                <h3>Контакты</h3>
+                <p><strong>Телефон:</strong> <a href="tel:+79296159054">+7(929)615-90-54</a></p>
+                <p><strong>E-mail:</strong> <a href="mailto:info@ai-rpa.ru">info@ai-rpa.ru</a></p>
+                <p><strong>Адрес:</strong> 125167, Москва, пр-кт Ленинградский, д. 47, стр. 2, помещение 28А</p>
+                <p><strong>Время работы:</strong> пн-пт: 9.00 - 18.00</p>
+            </div>
+        </div>
+        <div class="ts-footer__bottom">
+            <p>© 2025 Technostation: AI-RPA</p>
+            <p><a href="politika-konfidenczialnosti.html" aria-current="page">Политика конфиденциальности</a></p>
+        </div>
+    </footer>
+
+    <a class="ts-floating-cta" href="#ts-contact">Связаться с нами</a>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/progress.html
+++ b/progress.html
@@ -189,7 +189,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/xochu-poprobovat.html
+++ b/xochu-poprobovat.html
@@ -187,7 +187,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/Анализ текущих тенденций и прогноз развития роботизации бизнес-процессов в мире.html
+++ b/Анализ текущих тенденций и прогноз развития роботизации бизнес-процессов в мире.html
@@ -246,7 +246,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/Полезные материалы по роботизации процессов.html
+++ b/Полезные материалы по роботизации процессов.html
@@ -195,7 +195,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/Преимущества RPA для малого и среднего бизнеса.html
+++ b/Преимущества RPA для малого и среднего бизнеса.html
@@ -506,7 +506,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/Применение RPA в российских компаниях и государственном секторе.html
+++ b/Применение RPA в российских компаниях и государственном секторе.html
@@ -312,7 +312,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/Примеры успешных внедрений в малом, среднем и крупном бизнесе.html
+++ b/Примеры успешных внедрений в малом, среднем и крупном бизнесе.html
@@ -402,7 +402,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/Советы по успешному внедрению RPA в вашу компанию.html
+++ b/Советы по успешному внедрению RPA в вашу компанию.html
@@ -320,7 +320,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/Стек используемых технологий и языки программирования в наших RPA-решениях.html
+++ b/Стек используемых технологий и языки программирования в наших RPA-решениях.html
@@ -565,7 +565,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/Тенденции и будущее RPA_ чего ожидать_.html
+++ b/Тенденции и будущее RPA_ чего ожидать_.html
@@ -268,7 +268,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 


### PR DESCRIPTION
## Summary
- add a dedicated privacy policy page with the company policy text and a link to the Article 9 consent PDF
- update footer messaging across the site to point to the new privacy policy page

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e2e7920a5483308fb7f61ed612575b