### PR TITLE
Align navigation and footer across pages

### DIFF
--- a/individualnyij-podxod.html
+++ b/individualnyij-podxod.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -147,7 +148,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/kalkulyator-effektivnosti.html
+++ b/kalkulyator-effektivnosti.html
@@ -22,13 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -140,16 +142,47 @@
             </div>
         </section>
     </main>
-
-    <footer class="ts-footer" data-animate="section">
-        <div class="ts-container">
-            <div class="ts-footer__top">
-                <a class="ts-footer__logo" href="index.html#ts-home">Technostation: AI-RPA</a>
-                <p>Комплексная роботизация процессов — от анализа до поддержки.</p>
+    <footer class="ts-footer">
+        <div class="ts-container ts-grid ts-grid--footer">
+            <div>
+                <h2 class="ts-footer__logo">Technostation: AI-RPA</h2>
+                <p>Наши виртуальные роботы подстраиваются под ваши процессы, устраняя рутину и эмулируя действия сотрудников. Ваша система остается неизменной, а бизнес фокусируется на росте и увеличении эффективности.</p>
+                <div class="ts-footer__socials">
+                    <a href="https://wa.me/79296159054/" aria-label="WhatsApp"><span>WhatsApp</span></a>
+                    <a href="https://t.me/Yaroslav_TechnoStation" aria-label="Telegram"><span>Telegram</span></a>
+                </div>
             </div>
-            <div class="ts-footer__bottom">
-                <span>© 2024 Technostation. Все права защищены.</span>
+            <div>
+                <h3>Навигация</h3>
+                <ul>
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                </ul>
             </div>
+            <div>
+                <h3>Материалы</h3>
+                <ul>
+                    <li><a href="Полезные материалы по роботизации процессов.html">Все статьи</a></li>
+                    <li><a href="Преимущества RPA для малого и среднего бизнеса.html">Преимущества RPA</a></li>
+                    <li><a href="Примеры успешных внедрений в малом, среднем и крупном бизнесе.html">Кейсы внедрений</a></li>
+                    <li><a href="Стек используемых технологий и языки программирования в наших RPA-решениях.html">Стек технологий</a></li>
+                </ul>
+            </div>
+            <div class="ts-footer__contact">
+                <h3>Контакты</h3>
+                <p><strong>Телефон:</strong> <a href="tel:+79296159054">+7(929)615-90-54</a></p>
+                <p><strong>E-mail:</strong> <a href="mailto:info@ai-rpa.ru">info@ai-rpa.ru</a></p>
+                <p><strong>Адрес:</strong> 125167, Москва, пр-кт Ленинградский, д. 47, стр. 2, помещение 28А</p>
+                <p><strong>Время работы:</strong> пн-пт: 9.00 - 18.00</p>
+            </div>
+        </div>
+        <div class="ts-footer__bottom">
+            <p>© 2025 Technostation: AI-RPA</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/kontakty.html
+++ b/kontakty.html
@@ -25,14 +25,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
-                        <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html" aria-current="page">Контакты</a></li>
-                    </ul>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -194,15 +195,11 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>
                 <h2 class="ts-footer__logo">Technostation: AI-RPA</h2>
-                <p>
-                    Наши виртуальные роботы подстраиваются под ваши процессы, устраняя рутину и эмулируя действия сотрудников. Ваша система
-                    остается неизменной, а бизнес фокусируется на росте и увеличении эффективности.
-                </p>
+                <p>Наши виртуальные роботы подстраиваются под ваши процессы, устраняя рутину и эмулируя действия сотрудников. Ваша система остается неизменной, а бизнес фокусируется на росте и увеличении эффективности.</p>
                 <div class="ts-footer__socials">
                     <a href="https://wa.me/79296159054/" aria-label="WhatsApp"><span>WhatsApp</span></a>
                     <a href="https://t.me/Yaroslav_TechnoStation" aria-label="Telegram"><span>Telegram</span></a>
@@ -238,7 +235,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/maksimum.html
+++ b/maksimum.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -147,7 +148,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/o-nas.html
+++ b/o-nas.html
@@ -25,14 +25,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
-                        <li><a href="o-nas.html" aria-current="page">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -285,7 +286,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/oczenka-proekta.html
+++ b/oczenka-proekta.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -144,7 +145,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/partner-programmy.html
+++ b/partner-programmy.html
@@ -25,15 +25,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
-                        <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="partner-programmy.html" aria-current="page">Партнерские программы</a></li>
-                        <li><a href="#ts-contact">Контакты</a></li>
-                    </ul>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
                 </nav>
             </div>
@@ -196,12 +196,15 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
-        <div class="ts-container">
+        <div class="ts-container ts-grid ts-grid--footer">
             <div>
-                <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
-                <p>Решения по роботизации процессов, которые помогают бизнесу расти быстрее.</p>
+                <h2 class="ts-footer__logo">Technostation: AI-RPA</h2>
+                <p>Наши виртуальные роботы подстраиваются под ваши процессы, устраняя рутину и эмулируя действия сотрудников. Ваша система остается неизменной, а бизнес фокусируется на росте и увеличении эффективности.</p>
+                <div class="ts-footer__socials">
+                    <a href="https://wa.me/79296159054/" aria-label="WhatsApp"><span>WhatsApp</span></a>
+                    <a href="https://t.me/Yaroslav_TechnoStation" aria-label="Telegram"><span>Telegram</span></a>
+                </div>
             </div>
             <div>
                 <h3>Навигация</h3>
@@ -211,8 +214,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
-                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
-                    <li><a href="index.html#ts-contact">Контакты</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
                 </ul>
             </div>
             <div>
@@ -234,7 +236,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/pervyie-shagi.html
+++ b/pervyie-shagi.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -147,7 +148,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/politika-konfidenczialnosti.html
+++ b/politika-konfidenczialnosti.html
@@ -25,14 +25,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
-                        <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="#ts-contact">Контакты</a></li>
-                    </ul>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
                 </nav>
             </div>
@@ -102,15 +103,15 @@
             </div>
         </section>
     </main>
-
-    <footer class="ts-footer" id="ts-contact">
-        <div class="ts-container ts-footer__grid">
+    <footer class="ts-footer">
+        <div class="ts-container ts-grid ts-grid--footer">
             <div>
-                <h3>О компании</h3>
-                <p>
-                    Technostation: AI-RPA — цифровая студия, которая автоматизирует бизнес-процессы с помощью роботов, сохраняя у
-                    правление за людьми.
-                </p>
+                <h2 class="ts-footer__logo">Technostation: AI-RPA</h2>
+                <p>Наши виртуальные роботы подстраиваются под ваши процессы, устраняя рутину и эмулируя действия сотрудников. Ваша система остается неизменной, а бизнес фокусируется на росте и увеличении эффективности.</p>
+                <div class="ts-footer__socials">
+                    <a href="https://wa.me/79296159054/" aria-label="WhatsApp"><span>WhatsApp</span></a>
+                    <a href="https://t.me/Yaroslav_TechnoStation" aria-label="Telegram"><span>Telegram</span></a>
+                </div>
             </div>
             <div>
                 <h3>Навигация</h3>
@@ -120,7 +121,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
-                    <li><a href="#ts-contact">Контакты</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
                 </ul>
             </div>
             <div>
@@ -142,7 +143,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p><a href="politika-konfidenczialnosti.html" aria-current="page">Политика конфиденциальности</a></p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/primery-rabot-robotov.html
+++ b/primery-rabot-robotov.html
@@ -28,6 +28,7 @@
                 <ul class="ts-nav__links">
                     <li><a href="index.html#ts-services">Услуги</a></li>
                     <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
                     <li><a href="kontakty.html">Контакты</a></li>
@@ -152,20 +153,47 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
-        <div class="ts-container">
-            <div class="ts-footer__top">
-                <div>
-                    <h2>Готовы обсудить свой проект?</h2>
-                    <p>Свяжитесь с нами, и мы подберём оптимальное решение под ваши процессы и задачи.</p>
+        <div class="ts-container ts-grid ts-grid--footer">
+            <div>
+                <h2 class="ts-footer__logo">Technostation: AI-RPA</h2>
+                <p>Наши виртуальные роботы подстраиваются под ваши процессы, устраняя рутину и эмулируя действия сотрудников. Ваша система остается неизменной, а бизнес фокусируется на росте и увеличении эффективности.</p>
+                <div class="ts-footer__socials">
+                    <a href="https://wa.me/79296159054/" aria-label="WhatsApp"><span>WhatsApp</span></a>
+                    <a href="https://t.me/Yaroslav_TechnoStation" aria-label="Telegram"><span>Telegram</span></a>
                 </div>
-                <a class="ts-button ts-button--primary" href="kontakty.html#ts-contact-form">Оставить заявку</a>
             </div>
-            <div class="ts-footer__bottom">
-                <span>© Technostation: AI-RPA</span>
-                <span>Вместе делаем роботизацию удобной</span>
+            <div>
+                <h3>Навигация</h3>
+                <ul>
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                </ul>
             </div>
+            <div>
+                <h3>Материалы</h3>
+                <ul>
+                    <li><a href="Полезные материалы по роботизации процессов.html">Все статьи</a></li>
+                    <li><a href="Преимущества RPA для малого и среднего бизнеса.html">Преимущества RPA</a></li>
+                    <li><a href="Примеры успешных внедрений в малом, среднем и крупном бизнесе.html">Кейсы внедрений</a></li>
+                    <li><a href="Стек используемых технологий и языки программирования в наших RPA-решениях.html">Стек технологий</a></li>
+                </ul>
+            </div>
+            <div class="ts-footer__contact">
+                <h3>Контакты</h3>
+                <p><strong>Телефон:</strong> <a href="tel:+79296159054">+7(929)615-90-54</a></p>
+                <p><strong>E-mail:</strong> <a href="mailto:info@ai-rpa.ru">info@ai-rpa.ru</a></p>
+                <p><strong>Адрес:</strong> 125167, Москва, пр-кт Ленинградский, д. 47, стр. 2, помещение 28А</p>
+                <p><strong>Время работы:</strong> пн-пт: 9.00 - 18.00</p>
+            </div>
+        </div>
+        <div class="ts-footer__bottom">
+            <p>© 2025 Technostation: AI-RPA</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/progress.html
+++ b/progress.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -148,7 +149,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/referalnyij-i-agentskij-dogovory.html
+++ b/referalnyij-i-agentskij-dogovory.html
@@ -25,15 +25,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
-                        <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="partner-programmy.html" aria-current="page">Партнерские программы</a></li>
-                        <li><a href="#ts-contact">Контакты</a></li>
-                    </ul>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                    <li><a href="o-nas.html">О нас</a></li>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="#ts-contact">Связаться с нами</a>
                 </nav>
             </div>
@@ -184,12 +184,15 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
-        <div class="ts-container">
+        <div class="ts-container ts-grid ts-grid--footer">
             <div>
-                <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
-                <p>Решения по роботизации процессов, которые помогают бизнесу расти быстрее.</p>
+                <h2 class="ts-footer__logo">Technostation: AI-RPA</h2>
+                <p>Наши виртуальные роботы подстраиваются под ваши процессы, устраняя рутину и эмулируя действия сотрудников. Ваша система остается неизменной, а бизнес фокусируется на росте и увеличении эффективности.</p>
+                <div class="ts-footer__socials">
+                    <a href="https://wa.me/79296159054/" aria-label="WhatsApp"><span>WhatsApp</span></a>
+                    <a href="https://t.me/Yaroslav_TechnoStation" aria-label="Telegram"><span>Telegram</span></a>
+                </div>
             </div>
             <div>
                 <h3>Навигация</h3>
@@ -199,8 +202,7 @@
                     <li><a href="o-nas.html">О нас</a></li>
                     <li><a href="index.html#ts-pricing">Цены</a></li>
                     <li><a href="index.html#ts-faq">FAQ</a></li>
-                    <li><a href="partner-programmy.html">Партнерские программы</a></li>
-                    <li><a href="index.html#ts-contact">Контакты</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
                 </ul>
             </div>
             <div>
@@ -222,7 +224,7 @@
         </div>
         <div class="ts-footer__bottom">
             <p>© 2025 Technostation: AI-RPA</p>
-            <p>Политика конфиденциальности предоставляется по запросу.</p>
+            <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
 

--- a/xochu-poprobovat.html
+++ b/xochu-poprobovat.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -146,7 +147,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/Анализ текущих тенденций и прогноз развития роботизации бизнес-процессов в мире.html
+++ b/Анализ текущих тенденций и прогноз развития роботизации бизнес-процессов в мире.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -205,7 +206,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/Полезные материалы по роботизации процессов.html
+++ b/Полезные материалы по роботизации процессов.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -154,7 +155,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/Преимущества RPA для малого и среднего бизнеса.html
+++ b/Преимущества RPA для малого и среднего бизнеса.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -465,7 +466,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/Применение RPA в российских компаниях и государственном секторе.html
+++ b/Применение RPA в российских компаниях и государственном секторе.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -271,7 +272,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/Примеры успешных внедрений в малом, среднем и крупном бизнесе.html
+++ b/Примеры успешных внедрений в малом, среднем и крупном бизнесе.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -361,7 +362,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/Советы по успешному внедрению RPA в вашу компанию.html
+++ b/Советы по успешному внедрению RPA в вашу компанию.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -279,7 +280,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/Стек используемых технологий и языки программирования в наших RPA-решениях.html
+++ b/Стек используемых технологий и языки программирования в наших RPA-решениях.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -524,7 +525,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>

--- a/Тенденции и будущее RPA_ чего ожидать_.html
+++ b/Тенденции и будущее RPA_ чего ожидать_.html
@@ -22,14 +22,15 @@
                         <span></span>
                         <span></span>
                     </label>
-                    <ul class="ts-nav__links">
-                        <li><a href="index.html#ts-services">Услуги</a></li>
-                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                <ul class="ts-nav__links">
+                    <li><a href="index.html#ts-services">Услуги</a></li>
+                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
                     <li><a href="o-nas.html">О нас</a></li>
-                        <li><a href="index.html#ts-pricing">Цены</a></li>
-                        <li><a href="index.html#ts-faq">FAQ</a></li>
-                        <li><a href="kontakty.html">Контакты</a></li>
-                    </ul>
+                    <li><a href="index.html#ts-pricing">Цены</a></li>
+                    <li><a href="index.html#ts-faq">FAQ</a></li>
+                    <li><a href="kontakty.html">Контакты</a></li>
+                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                </ul>
                     <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
                 </nav>
             </div>
@@ -227,7 +228,6 @@
             </div>
         </section>
     </main>
-
     <footer class="ts-footer">
         <div class="ts-container ts-grid ts-grid--footer">
             <div>


### PR DESCRIPTION
## Summary
- add the missing "О нас" and "Примеры роботов" links to every secondary navigation to match the homepage menu
- replace simplified footers with the full site footer, including the privacy policy link and contact information

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68e2ea3ec19c8330b691aaf5487c1011