### PR TITLE
Fix contact form layout on ROI calculator page

### DIFF
--- a/kalkulyator-effektivnosti.html
+++ b/kalkulyator-effektivnosti.html
@@ -119,22 +119,27 @@
                     <h2>Связаться с нами</h2>
                 </div>
                 <form class="ts-contact__form" action="#" method="post" data-animate="fade-up" data-animate-delay="0.1">
-                    <div class="ts-contact__grid">
-                        <label class="ts-contact__field">
-                            <span>Имя</span>
+                    <div class="ts-form-grid">
+                        <label class="ts-form-field">
+                            <span class="ts-form-label">Имя*</span>
                             <input type="text" name="name" placeholder="Как к вам обращаться?" required />
                         </label>
-                        <label class="ts-contact__field">
-                            <span>Email</span>
+                        <label class="ts-form-field">
+                            <span class="ts-form-label">Email*</span>
                             <input type="email" name="email" placeholder="name@company.ru" required />
                         </label>
-                        <label class="ts-contact__field">
-                            <span>Телефон</span>
+                        <label class="ts-form-field">
+                            <span class="ts-form-label">Телефон</span>
                             <input type="tel" name="phone" placeholder="+7 (___) ___-__-__" />
                         </label>
-                        <label class="ts-contact__field ts-contact__field--wide">
-                            <span>Сообщение</span>
+                        <label class="ts-form-field ts-form-field--full">
+                            <span class="ts-form-label">Сообщение</span>
                             <textarea name="message" rows="4" placeholder="Расскажите о задаче, которую нужно решить"></textarea>
+                        </label>
+                        <label class="ts-form-checkbox ts-form-field--full">
+                            <input type="checkbox" required />
+                            <span class="ts-checkbox"></span>
+                            <span>Даю согласие на обработку персональных данных в соответствии с Политикой конфиденциальности и Согласием на обработку персональных данных.</span>
                         </label>
                     </div>
                     <button class="ts-button ts-button--primary" type="submit">Отправить</button>


### PR DESCRIPTION
## Summary
- align the calculator page contact form markup with the shared form grid and field classes
- add the consent checkbox used on other pages so the section inherits the common styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2edf1374c833087f5d9355700821f