### PR TITLE
Align navigation and disable subpage preload animations

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -54,6 +54,12 @@ body.ts-page {
     margin: 0 auto;
 }
 
+.ts-subpage [data-animate] {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+}
+
 [data-animate] {
     opacity: 1;
     transform: none;
@@ -202,9 +208,18 @@ body.ts-page {
 
 .ts-hero {
     position: relative;
-    padding: 3rem 0 6rem;
+    padding: 0 0 6rem;
     background: linear-gradient(135deg, rgba(245, 241, 227, 0.95) 0%, rgba(246, 196, 69, 0.22) 45%, rgba(242, 153, 74, 0.18) 100%);
     overflow: hidden;
+}
+
+.ts-hero__nav {
+    position: relative;
+    z-index: 12;
+    padding: clamp(1rem, 2vw, 1.5rem) 0;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(60, 74, 31, 0.08);
 }
 
 .ts-hero::before,
@@ -369,6 +384,7 @@ body.ts-page {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 3.5rem;
     align-items: center;
+    margin-top: clamp(2.5rem, 5vw, 4rem);
 }
 
 .ts-hero__text h1 {
@@ -2012,7 +2028,7 @@ body.ts-page {
     position: sticky;
     top: 0;
     z-index: 12;
-    padding: 1.1rem 0;
+    padding: clamp(1rem, 2vw, 1.5rem) 0;
     background: rgba(255, 255, 255, 0.85);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid rgba(60, 74, 31, 0.08);
@@ -2053,6 +2069,10 @@ body.ts-page {
     z-index: 2;
     pointer-events: none;
     transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.ts-subpage .ts-subheader__scroll-hint {
+    display: none;
 }
 
 .ts-subheader__scroll-hint.is-hidden {
@@ -2833,7 +2853,7 @@ body.ts-page {
 
 @media (max-width: 640px) {
     .ts-hero {
-        padding: 2.75rem 0 3.5rem;
+        padding: 0 0 3.5rem;
     }
 
     .ts-nav {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const anchorLinks = document.querySelectorAll('a[href^="#"]');
     const scrollHints = document.querySelectorAll('.ts-subheader__scroll-hint');
     const floatingCta = document.querySelector('.ts-floating-cta');
+    const isSubpage = document.body.classList.contains('ts-subpage');
     let scrollTicking = false;
 
     const addMediaQueryListener = (mediaQueryList, callback) => {
@@ -33,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
-    const shouldUseObserver = supportsIntersectionObserver && !prefersReducedMotion.matches;
+    const shouldUseObserver = supportsIntersectionObserver && !prefersReducedMotion.matches && !isSubpage;
 
     anchorLinks.forEach((link) => {
         link.addEventListener('click', (event) => {
@@ -121,6 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     if (!shouldUseObserver) {
+        document.documentElement.classList.remove('has-animations');
         showAnimatedElements();
         syncCountersImmediately();
     }

--- a/index.html
+++ b/index.html
@@ -13,26 +13,30 @@
 <body class="ts-page">
     <header class="ts-hero" id="ts-home" data-animate="hero">
         <div class="ts-hero__overlay"></div>
+        <div class="ts-hero__nav">
+            <div class="ts-container">
+                <nav class="ts-nav" aria-label="Главная навигация">
+                    <a class="ts-logo" href="#ts-home">Technostation: AI-RPA</a>
+                    <input id="ts-nav-toggle" class="ts-nav__checkbox" type="checkbox" aria-hidden="true" />
+                    <label for="ts-nav-toggle" class="ts-nav__toggle" aria-label="Открыть меню">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </label>
+                    <ul class="ts-nav__links">
+                        <li><a href="#ts-services">Услуги</a></li>
+                        <li><a href="#ts-portfolio">Портфолио</a></li>
+                        <li><a href="o-nas.html">О нас</a></li>
+                        <li><a href="#ts-pricing">Цены</a></li>
+                        <li><a href="#ts-faq">FAQ</a></li>
+                        <li><a href="kontakty.html">Контакты</a></li>
+                        <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
+                    </ul>
+                    <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
+                </nav>
+            </div>
+        </div>
         <div class="ts-container">
-            <nav class="ts-nav" aria-label="Главная навигация">
-                <a class="ts-logo" href="#ts-home">Technostation: AI-RPA</a>
-                <input id="ts-nav-toggle" class="ts-nav__checkbox" type="checkbox" aria-hidden="true" />
-                <label for="ts-nav-toggle" class="ts-nav__toggle" aria-label="Открыть меню">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </label>
-                <ul class="ts-nav__links">
-                    <li><a href="#ts-services">Услуги</a></li>
-                    <li><a href="#ts-portfolio">Портфолио</a></li>
-                    <li><a href="o-nas.html">О нас</a></li>
-                    <li><a href="#ts-pricing">Цены</a></li>
-                    <li><a href="#ts-faq">FAQ</a></li>
-                    <li><a href="kontakty.html">Контакты</a></li>
-                    <li><a href="primery-rabot-robotov.html">Примеры роботов</a></li>
-                </ul>
-                <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
-            </nav>
             <div class="ts-hero__content">
                 <div class="ts-hero__text" data-animate="fade-up">
                     <h1>Инновационные решения для роботизации рутинных задач</h1>


### PR DESCRIPTION
## Summary
- add a dedicated header bar on the home page so the navigation matches the subpage positioning and spacing
- hide the scroll hint and disable entrance animations on subpages so their content renders immediately
- update the animation bootstrap script to skip the intersection observer on subpages and keep styles in sync

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e35497687483308552abc34cce2df7