### PR TITLE
Replace contact map with Yandex embed

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1888,6 +1888,18 @@ body.ts-page {
     gap: 2rem;
 }
 
+.ts-map-embed {
+    margin-top: 2.5rem;
+}
+
+.ts-map-embed iframe {
+    width: 100%;
+    min-height: clamp(320px, 45vw, 520px);
+    border: 0;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
+}
+
 .ts-form-grid {
     display: grid;
     gap: 1.5rem;

--- a/kontakty.html
+++ b/kontakty.html
@@ -198,10 +198,11 @@
                 <div class="ts-map-embed" data-animate="fade-up" data-animate-delay="0.1">
                     <iframe
                         title="Карта с адресом Technostation"
-                        src="https://maps.google.com/maps?q=55.8195,37.4969&amp;z=15&amp;output=embed"
+                        src="https://yandex.ru/map-widget/v1/?ll=37.4969%2C55.8195&amp;pt=37.4969,55.8195,pm2rdm&amp;z=16"
                         loading="lazy"
                         allowfullscreen
                         referrerpolicy="no-referrer-when-downgrade"
+                        frameborder="0"
                     ></iframe>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the Google Maps iframe on the contacts page with a Yandex Maps embed centered on the office location
- style the map embed to span the full content width with an increased height and rounded corners

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e364fa3c1c8330b0cc1ce62143a5ba