### PR TITLE
Remove metrics section from About page

### DIFF
--- a/o-nas.html
+++ b/o-nas.html
@@ -111,31 +111,6 @@
             </div>
         </section>
 
-        <section class="ts-metrics ts-about-metrics" aria-label="Ключевые показатели" data-animate="section">
-            <div class="ts-container">
-                <div class="ts-metrics__wrapper">
-                    <div class="ts-metrics__visual" aria-hidden="true" data-animate="float">
-                        <img src="assets/images/robot-mascot.svg" alt="Цифровой помощник Technostation" />
-                        <div class="ts-metrics__glow"></div>
-                    </div>
-                    <div class="ts-metrics__stats">
-                        <article data-animate="counter" data-animate-delay="0">
-                            <h3><span class="ts-counter" data-counter-target="9" data-counter-suffix="+">0</span></h3>
-                            <p>лет опыта команды</p>
-                        </article>
-                        <article data-animate="counter" data-animate-delay="0.1">
-                            <h3><span class="ts-counter" data-counter-target="223" data-counter-suffix="+">0</span></h3>
-                            <p>реализованных проектов</p>
-                        </article>
-                        <article data-animate="counter" data-animate-delay="0.2">
-                            <h3><span class="ts-counter" data-counter-target="28" data-counter-suffix="+">0</span></h3>
-                            <p>долгосрочных клиентов</p>
-                        </article>
-                    </div>
-                </div>
-            </div>
-        </section>
-
         <section class="ts-about-competencies" data-animate="section">
             <div class="ts-container">
                 <div class="ts-section-header ts-section-header--left" data-animate="fade-up">


### PR DESCRIPTION
## Summary
- remove the metrics section from the About page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3653ef9e8833082921b96787bb9e1