### PR TITLE
Add hero video modal overlay

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -49,6 +49,10 @@ body.ts-page {
     display: block;
 }
 
+body.ts-page.ts-modal-open {
+    overflow: hidden;
+}
+
 .ts-container {
     width: var(--container-width);
     margin: 0 auto;
@@ -3256,5 +3260,88 @@ body.ts-page {
 
     .ts-calculator__result-value {
         font-size: 1.5rem;
+    }
+}
+
+.ts-video-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background-color: rgba(33, 33, 33, 0.72);
+    backdrop-filter: blur(4px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 1200;
+}
+
+.ts-video-modal.is-open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.ts-video-modal__backdrop {
+    position: absolute;
+    inset: 0;
+}
+
+.ts-video-modal__dialog {
+    position: relative;
+    width: min(960px, 100%);
+    background-color: #0d0d0d;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+    overflow: hidden;
+}
+
+.ts-video-modal__player {
+    display: block;
+    width: 100%;
+    height: auto;
+    aspect-ratio: 16 / 9;
+    background-color: #000;
+}
+
+.ts-video-modal__close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: none;
+    background-color: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    font-size: 28px;
+    line-height: 1;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.ts-video-modal__close span {
+    display: block;
+    transform: translateY(-2px);
+}
+
+.ts-video-modal__close:hover,
+.ts-video-modal__close:focus {
+    background-color: rgba(255, 255, 255, 0.2);
+    transform: scale(1.05);
+}
+
+@media (max-width: 640px) {
+    .ts-video-modal {
+        padding: 16px;
+    }
+
+    .ts-video-modal__close {
+        width: 40px;
+        height: 40px;
+        font-size: 24px;
     }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -370,4 +370,92 @@ document.addEventListener('DOMContentLoaded', () => {
         panelSelector: '.ts-portfolio__panel',
         targetAttribute: 'caseTarget',
     });
+
+    const videoModal = document.querySelector('.ts-video-modal');
+    const videoTrigger = document.querySelector('[data-video-trigger]');
+
+    if (videoModal && videoTrigger) {
+        const videoPlayer = videoModal.querySelector('video');
+        const closeButtons = Array.from(videoModal.querySelectorAll('[data-video-close]'));
+        const dialog = videoModal.querySelector('.ts-video-modal__dialog');
+        let previouslyFocusedElement = null;
+
+        const isOpen = () => videoModal.classList.contains('is-open');
+
+        const focusVideoPlayer = () => {
+            if (videoPlayer && typeof videoPlayer.focus === 'function') {
+                requestAnimationFrame(() => {
+                    videoPlayer.focus({ preventScroll: true });
+                });
+            }
+        };
+
+        const openVideoModal = () => {
+            previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+            videoModal.classList.add('is-open');
+            videoModal.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('ts-modal-open');
+
+            if (videoPlayer) {
+                if (videoPlayer.readyState > 0) {
+                    videoPlayer.currentTime = 0;
+                }
+
+                const playPromise = videoPlayer.play();
+                if (playPromise && typeof playPromise.catch === 'function') {
+                    playPromise.catch(() => {});
+                }
+            }
+
+            focusVideoPlayer();
+        };
+
+        const closeVideoModal = () => {
+            if (!isOpen()) {
+                return;
+            }
+
+            videoModal.classList.remove('is-open');
+            videoModal.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('ts-modal-open');
+
+            if (videoPlayer) {
+                videoPlayer.pause();
+                videoPlayer.currentTime = 0;
+            }
+
+            if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function') {
+                previouslyFocusedElement.focus({ preventScroll: true });
+            }
+
+            previouslyFocusedElement = null;
+        };
+
+        videoTrigger.addEventListener('click', () => {
+            openVideoModal();
+        });
+
+        closeButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                closeVideoModal();
+            });
+        });
+
+        videoModal.addEventListener('click', (event) => {
+            if (!dialog) {
+                return;
+            }
+
+            if (!dialog.contains(event.target)) {
+                closeVideoModal();
+            }
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && isOpen()) {
+                event.preventDefault();
+                closeVideoModal();
+            }
+        });
+    }
 });

--- a/index.html
+++ b/index.html
@@ -45,7 +45,9 @@
                         без необходимости менять вашу инфраструктуру.
                     </p>
                     <div class="ts-hero__actions">
-                        <a class="ts-button ts-button--primary" href="https://ai-rpa.ru/assets/ai-6.mp4" target="_blank" rel="noopener">Смотреть видео</a>
+                        <button class="ts-button ts-button--primary" type="button" data-video-trigger>
+                            Смотреть видео
+                        </button>
                         <a class="ts-button ts-button--outline" href="kalkulyator-effektivnosti.html">Рассчитать эффективность внедрения RPA</a>
                     </div>
                 </div>
@@ -1217,6 +1219,19 @@
     </footer>
 
     <a class="ts-floating-cta" href="kontakty.html#ts-contact-form">Связаться с нами</a>
+
+    <div class="ts-video-modal" id="ts-video-modal" aria-hidden="true" role="dialog" aria-modal="true">
+        <div class="ts-video-modal__backdrop" data-video-close></div>
+        <div class="ts-video-modal__dialog" role="document">
+            <button class="ts-video-modal__close" type="button" aria-label="Закрыть видео" data-video-close>
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <video class="ts-video-modal__player" controls preload="metadata">
+                <source src="assets/videos/ai-6.mp4" type="video/mp4" />
+                Ваш браузер не поддерживает воспроизведение видео.
+            </video>
+        </div>
+    </div>
 
     <script src="assets/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- replace the hero section video link with a button that opens an on-page modal
- add HTML, CSS, and JavaScript to display a local ai-6.mp4 video inside a closable overlay
- prevent background scrolling and reset playback when the modal is closed

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e3728a5f108330bda02d85b5f4ab20