### PR TITLE
Redesign robot examples gallery experience

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -621,55 +621,215 @@ body.ts-page.ts-modal-open {
     padding: clamp(3rem, 7vw, 5.5rem) 0 clamp(3rem, 7vw, 5.5rem);
 }
 
+.ts-video-gallery__intro {
+    max-width: 720px;
+    margin: 0 auto clamp(2.5rem, 6vw, 3.5rem);
+    text-align: center;
+}
+
+.ts-video-gallery__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.85rem;
+    margin-bottom: 1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--color-accent);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+}
+
+.ts-video-gallery__intro h2 {
+    margin: 0 0 1rem;
+    font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+.ts-video-gallery__intro p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.72);
+    font-size: clamp(1rem, 2.5vw, 1.1rem);
+    line-height: 1.65;
+}
+
 .ts-video-gallery__grid {
     display: grid;
-    gap: clamp(1.5rem, 3vw, 2.25rem);
+    gap: clamp(1.75rem, 3.5vw, 2.75rem);
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    list-style: none;
+    padding: 0;
+    margin: 0;
 }
 
 .ts-video-gallery__grid--wall {
     gap: clamp(1.75rem, 3.5vw, 2.75rem);
 }
 
-.ts-video-tile {
+.ts-video-card {
     position: relative;
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-lg);
+    background: linear-gradient(140deg, rgba(89, 200, 255, 0.08), rgba(112, 59, 255, 0.12));
+    box-shadow: 0 28px 64px rgba(13, 18, 33, 0.35);
     overflow: hidden;
-    background: linear-gradient(135deg, rgba(246, 196, 69, 0.38), rgba(242, 153, 74, 0.24));
-    padding: clamp(0.5rem, 1vw, 0.75rem);
-    box-shadow: 0 22px 48px rgba(58, 72, 44, 0.18);
     transition: transform 0.35s ease, box-shadow 0.35s ease;
 }
 
-.ts-video-tile::before {
+.ts-video-card::before {
     content: "";
     position: absolute;
     inset: 0;
-    border-radius: inherit;
-    background: radial-gradient(circle at top, rgba(255, 255, 255, 0.35), transparent 55%);
+    background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.18), transparent 60%);
     opacity: 0;
     transition: opacity 0.35s ease;
     pointer-events: none;
 }
 
-.ts-video-tile video {
-    display: block;
+.ts-video-card__button {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
     width: 100%;
-    border-radius: calc(var(--radius-md) - clamp(0.5rem, 1vw, 0.75rem));
+    height: 100%;
+    padding: clamp(1.75rem, 3.5vw, 2.25rem);
+    background: none;
+    border: none;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    text-align: left;
+    color: inherit;
+    position: relative;
+    z-index: 1;
+}
+
+.ts-video-card__button:focus {
+    outline: 2px solid rgba(255, 255, 255, 0.4);
+    outline-offset: 4px;
+}
+
+.ts-video-card__thumb {
+    position: relative;
+    display: grid;
+    place-items: center;
+    border-radius: calc(var(--radius-lg) - 1rem);
     aspect-ratio: 16 / 9;
-    object-fit: cover;
-    background: #0c1014;
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(22, 28, 46, 0.85), rgba(17, 23, 41, 0.65));
 }
 
-.ts-video-tile:hover,
-.ts-video-tile:focus-within {
-    transform: translateY(-8px);
-    box-shadow: 0 34px 68px rgba(41, 51, 31, 0.25);
+.ts-video-card__glow {
+    position: absolute;
+    inset: -40%;
+    background: radial-gradient(circle, rgba(87, 230, 255, 0.28), transparent 70%);
+    animation: ts-pulse 5s ease-in-out infinite;
+    pointer-events: none;
 }
 
-.ts-video-tile:hover::before,
-.ts-video-tile:focus-within::before {
+.ts-video-card__play {
+    position: relative;
+    display: grid;
+    place-items: center;
+    width: 68px;
+    height: 68px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-accent);
+    box-shadow: 0 12px 30px rgba(12, 17, 36, 0.45);
+    transition: transform 0.35s ease, background 0.35s ease, color 0.35s ease;
+}
+
+.ts-video-card__play::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(2px);
+}
+
+.ts-video-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.ts-video-card__category {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.78);
+}
+
+.ts-video-card__title {
+    display: block;
+    font-size: clamp(1.15rem, 2.4vw, 1.35rem);
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.ts-video-card__description {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+    line-height: 1.6;
+}
+
+.ts-video-card__meta {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.5);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.ts-video-card:hover,
+.ts-video-card:focus-within {
+    transform: translateY(-10px);
+    box-shadow: 0 36px 80px rgba(10, 14, 28, 0.45);
+}
+
+.ts-video-card:hover::before,
+.ts-video-card:focus-within::before {
     opacity: 1;
+}
+
+.ts-video-card:hover .ts-video-card__play,
+.ts-video-card:focus-within .ts-video-card__play {
+    transform: scale(1.05);
+    background: rgba(87, 230, 255, 0.2);
+    color: #fff;
+}
+
+@media (max-width: 600px) {
+    .ts-video-card__button {
+        gap: 1.25rem;
+        padding: 1.5rem;
+    }
+
+    .ts-video-card__thumb {
+        border-radius: calc(var(--radius-lg) - 0.75rem);
+    }
+}
+
+@keyframes ts-pulse {
+    0%,
+    100% {
+        transform: scale(0.95);
+        opacity: 0.85;
+    }
+
+    50% {
+        transform: scale(1.05);
+        opacity: 1;
+    }
 }
 
 .ts-grid {
@@ -3301,10 +3461,14 @@ body.ts-page.ts-modal-open {
 .ts-video-modal__dialog {
     position: relative;
     width: min(960px, 100%);
-    background-color: #0d0d0d;
+    background: linear-gradient(160deg, rgba(8, 12, 24, 0.96), rgba(18, 24, 38, 0.92));
     border-radius: var(--radius-md);
-    box-shadow: var(--shadow-soft);
-    overflow: hidden;
+    box-shadow: 0 38px 70px rgba(7, 10, 24, 0.6);
+    padding: clamp(1.5rem, 3vw, 2rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 2vw, 1.5rem);
+    overflow: visible;
 }
 
 .ts-video-modal__player {
@@ -3313,6 +3477,60 @@ body.ts-page.ts-modal-open {
     height: auto;
     aspect-ratio: 16 / 9;
     background-color: #000;
+    border-radius: calc(var(--radius-md) - 1rem);
+    box-shadow: 0 24px 50px rgba(5, 8, 20, 0.55);
+}
+
+.ts-video-modal__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color: #fff;
+}
+
+.ts-video-modal__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-accent);
+    opacity: 0.85;
+}
+
+.ts-video-modal__title {
+    margin: 0;
+    font-size: clamp(1.35rem, 3vw, 1.85rem);
+    line-height: 1.35;
+}
+
+.ts-video-modal__close {
+    position: absolute;
+    top: clamp(0.75rem, 1.5vw, 1.1rem);
+    right: clamp(0.75rem, 1.5vw, 1.1rem);
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.85);
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+.ts-video-modal__close span {
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.ts-video-modal__close:hover,
+.ts-video-modal__close:focus {
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
 }
 
 @media (max-width: 640px) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -372,10 +372,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const videoModal = document.querySelector('.ts-video-modal');
-    const videoTrigger = document.querySelector('[data-video-trigger]');
+    const videoTriggers = Array.from(document.querySelectorAll('[data-video-trigger]'));
 
-    if (videoModal && videoTrigger) {
+    if (videoModal && videoTriggers.length > 0) {
         const videoPlayer = videoModal.querySelector('video');
+        const videoSource = videoPlayer ? videoPlayer.querySelector('source') : null;
+        const modalTitle = videoModal.querySelector('.ts-video-modal__title');
         const closeButtons = Array.from(videoModal.querySelectorAll('[data-video-close]'));
         const dialog = videoModal.querySelector('.ts-video-modal__dialog');
         let previouslyFocusedElement = null;
@@ -390,8 +392,41 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         };
 
-        const openVideoModal = () => {
+        const setVideoContent = (trigger) => {
+            if (!videoPlayer || !(trigger instanceof HTMLElement)) {
+                return;
+            }
+
+            const videoSrc = trigger.getAttribute('data-video-src');
+            const videoType = trigger.getAttribute('data-video-type') || 'video/mp4';
+            const videoPoster = trigger.getAttribute('data-video-poster');
+            const videoTitle = trigger.getAttribute('data-video-title');
+
+            if (videoPoster) {
+                videoPlayer.setAttribute('poster', videoPoster);
+            } else {
+                videoPlayer.removeAttribute('poster');
+            }
+
+            if (videoSource) {
+                if (videoSrc) {
+                    videoSource.setAttribute('src', videoSrc);
+                }
+                videoSource.setAttribute('type', videoType);
+                videoPlayer.load();
+            } else if (videoSrc) {
+                videoPlayer.setAttribute('src', videoSrc);
+                videoPlayer.load();
+            }
+
+            if (modalTitle && videoTitle) {
+                modalTitle.textContent = videoTitle;
+            }
+        };
+
+        const openVideoModal = (trigger) => {
             previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+            setVideoContent(trigger);
             videoModal.classList.add('is-open');
             videoModal.setAttribute('aria-hidden', 'false');
             document.body.classList.add('ts-modal-open');
@@ -431,8 +466,10 @@ document.addEventListener('DOMContentLoaded', () => {
             previouslyFocusedElement = null;
         };
 
-        videoTrigger.addEventListener('click', () => {
-            openVideoModal();
+        videoTriggers.forEach((trigger) => {
+            trigger.addEventListener('click', () => {
+                openVideoModal(trigger);
+            });
         });
 
         closeButtons.forEach((button) => {

--- a/primery-rabot-robotov.html
+++ b/primery-rabot-robotov.html
@@ -51,43 +51,270 @@
     <main>
         <section class="ts-video-gallery" data-animate="section">
             <div class="ts-container">
-                <div class="ts-video-gallery__grid ts-video-gallery__grid--wall">
-                    <div class="ts-video-tile" data-animate="fade-up">
-                        <video src="assets/videos/firstvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.1">
-                        <video src="assets/videos/secondvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.2">
-                        <video src="assets/videos/thirdvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up">
-                        <video src="assets/videos/fourthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.1">
-                        <video src="assets/videos/fifthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.2">
-                        <video src="assets/videos/sixthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up">
-                        <video src="assets/videos/seventhvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.1">
-                        <video src="assets/videos/eighthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.2">
-                        <video src="assets/videos/ninthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
+                <div class="ts-video-gallery__intro" data-animate="fade-up">
+                    <span class="ts-video-gallery__eyebrow">Коллекция кейсов</span>
+                    <h2>Посмотрите, как работают наши роботы</h2>
+                    <p>
+                        Мы собрали самые популярные сценарии автоматизации: от финансовых операций до HR и поддержки клиентов.
+                        Нажмите на карточку, чтобы открыть подробное видео и увидеть процесс изнутри.
+                    </p>
                 </div>
+
+                <ul class="ts-video-gallery__grid ts-video-gallery__grid--wall">
+                    <li class="ts-video-card" data-animate="fade-up">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/firstvideo.mp4"
+                            data-video-title="Робот сверяет банковские выписки"
+                            aria-label="Смотреть видео «Робот сверяет банковские выписки»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">Финансы</span>
+                                <span class="ts-video-card__title">Робот сверяет банковские выписки</span>
+                                <p class="ts-video-card__description">
+                                    Автоматическая выгрузка и разбор выписок, сопоставление с платежами и формирование отчётов без
+                                    ручного участия.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 0:52</span>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-animate="fade-up" data-animate-delay="0.1">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/secondvideo.mp4"
+                            data-video-title="Робот подготавливает бухгалтерскую отчётность"
+                            aria-label="Смотреть видео «Робот подготавливает бухгалтерскую отчётность»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">Бэк-офис</span>
+                                <span class="ts-video-card__title">Робот подготавливает бухгалтерскую отчётность</span>
+                                <p class="ts-video-card__description">
+                                    Сбор первичных документов, проверка показателей и создание итоговых файлов для отправки в налоговую
+                                    службу.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 1:04</span>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-animate="fade-up" data-animate-delay="0.2">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/thirdvideo.mp4"
+                            data-video-title="Робот оформляет заявки на закупку"
+                            aria-label="Смотреть видео «Робот оформляет заявки на закупку»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">Закупки</span>
+                                <span class="ts-video-card__title">Робот оформляет заявки на закупку</span>
+                                <p class="ts-video-card__description">
+                                    Получение запросов от менеджеров, проверка лимитов, заполнение форм и отправка на согласование в ERP.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 0:47</span>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-animate="fade-up">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/fourthvideo.mp4"
+                            data-video-title="Робот ведёт персональные карточки сотрудников"
+                            aria-label="Смотреть видео «Робот ведёт персональные карточки сотрудников»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">HR</span>
+                                <span class="ts-video-card__title">Робот ведёт персональные карточки сотрудников</span>
+                                <p class="ts-video-card__description">
+                                    Обновление кадровых данных, оформление отпусков и подготовка справок для сотрудников в пару кликов.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 0:55</span>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-animate="fade-up" data-animate-delay="0.1">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/fifthvideo.mp4"
+                            data-video-title="Робот принимает обращения клиентов"
+                            aria-label="Смотреть видео «Робот принимает обращения клиентов»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">Поддержка</span>
+                                <span class="ts-video-card__title">Робот принимает обращения клиентов</span>
+                                <p class="ts-video-card__description">
+                                    Интеллектуальный анализ писем и заявок, распределение по SLA и моментальные ответы без очередей.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 0:49</span>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-animate="fade-up" data-animate-delay="0.2">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/sixthvideo.mp4"
+                            data-video-title="Робот собирает отчёты о продажах"
+                            aria-label="Смотреть видео «Робот собирает отчёты о продажах»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">Продажи</span>
+                                <span class="ts-video-card__title">Робот собирает отчёты о продажах</span>
+                                <p class="ts-video-card__description">
+                                    Выгрузка данных из CRM, построение аналитики в Power BI и отправка подборок менеджерам к началу дня.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 1:02</span>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-animate="fade-up">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/seventhvideo.mp4"
+                            data-video-title="Робот проверяет контрагентов"
+                            aria-label="Смотреть видео «Робот проверяет контрагентов»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">Комплаенс</span>
+                                <span class="ts-video-card__title">Робот проверяет контрагентов</span>
+                                <p class="ts-video-card__description">
+                                    Мониторинг реестров и санкционных списков, сбор выписок и создание заключений по каждой компании.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 0:58</span>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-animate="fade-up" data-animate-delay="0.1">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/eighthvideo.mp4"
+                            data-video-title="Робот управляет складскими остатками"
+                            aria-label="Смотреть видео «Робот управляет складскими остатками»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">Логистика</span>
+                                <span class="ts-video-card__title">Робот управляет складскими остатками</span>
+                                <p class="ts-video-card__description">
+                                    Контроль запасов, планирование дозагрузки и уведомления ответственным при риске дефицита.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 0:54</span>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-animate="fade-up" data-animate-delay="0.2">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/ninthvideo.mp4"
+                            data-video-title="Робот формирует персональные предложения"
+                            aria-label="Смотреть видео «Робот формирует персональные предложения»"
+                        >
+                            <span class="ts-video-card__thumb" aria-hidden="true">
+                                <span class="ts-video-card__glow"></span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                                        <path d="M8 5v14l11-7L8 5z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__content">
+                                <span class="ts-video-card__category">Маркетинг</span>
+                                <span class="ts-video-card__title">Робот формирует персональные предложения</span>
+                                <p class="ts-video-card__description">
+                                    Анализ поведения клиентов, сегментация и автоматическая отправка писем с персональными офферами.
+                                </p>
+                                <span class="ts-video-card__meta">Длительность: 1:08</span>
+                            </div>
+                        </button>
+                    </li>
+                </ul>
             </div>
         </section>
     </main>
@@ -134,6 +361,23 @@
             <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
+
+    <div class="ts-video-modal" id="ts-video-modal" aria-hidden="true" role="dialog" aria-modal="true">
+        <div class="ts-video-modal__backdrop" data-video-close></div>
+        <div class="ts-video-modal__dialog" role="document">
+            <button class="ts-video-modal__close" type="button" data-video-close aria-label="Закрыть видео">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <div class="ts-video-modal__header">
+                <span class="ts-video-modal__eyebrow">Видео-демонстрация</span>
+                <h2 class="ts-video-modal__title">Робот сверяет банковские выписки</h2>
+            </div>
+            <video class="ts-video-modal__player" controls preload="metadata">
+                <source src="assets/videos/firstvideo.mp4" type="video/mp4" />
+                Ваш браузер не поддерживает воспроизведение видео.
+            </video>
+        </div>
+    </div>
 
     <script src="assets/js/main.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- replace the plain video wall on the robot examples page with descriptive preview cards that open videos on demand
- add a reusable modal with close control, dynamic titles, and source swapping for each gallery item
- refresh gallery and modal styling for a more polished presentation across screen sizes

## Testing
- Manually viewed `primery-rabot-robotov.html` via `python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68e37d8f9b8c8330bf5f10673cb5f890