### PR TITLE
Ensure gallery intro text is black and adjust modal spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -6,6 +6,8 @@
     --color-cream-dark: #e5dcc7;
     --color-yellow: #f6c445;
     --color-orange: #f2994a;
+    --color-accent: #4c6ef5;
+    --color-accent-soft: #edf2ff;
     --color-text: #2d2a26;
     --color-muted: #6f6b64;
     --container-width: min(1120px, 90vw);
@@ -617,59 +619,484 @@ body.ts-page.ts-modal-open {
     text-align: left;
 }
 
+body.ts-page--gallery {
+    background: radial-gradient(140% 140% at 12% 8%, rgba(76, 110, 245, 0.12) 0%, transparent 55%),
+        radial-gradient(120% 120% at 88% 6%, rgba(242, 153, 74, 0.14) 0%, transparent 52%),
+        #fbf9f3;
+}
+
 .ts-video-gallery {
-    padding: clamp(3rem, 7vw, 5.5rem) 0 clamp(3rem, 7vw, 5.5rem);
+    position: relative;
+    padding: clamp(3.5rem, 7vw, 6rem) 0 clamp(4rem, 8vw, 6.5rem);
+}
+
+.ts-video-gallery::before,
+.ts-video-gallery::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.ts-video-gallery::before {
+    background: radial-gradient(90% 80% at 20% 0%, rgba(76, 110, 245, 0.16) 0%, transparent 65%);
+    transform: translateY(-35%);
+}
+
+.ts-video-gallery::after {
+    background: radial-gradient(80% 80% at 80% 100%, rgba(242, 153, 74, 0.12) 0%, transparent 65%);
+    transform: translateY(30%);
+}
+
+.ts-video-gallery > .ts-container {
+    position: relative;
+    z-index: 1;
+}
+
+.ts-video-gallery__intro {
+    max-width: 760px;
+    margin: 0 auto clamp(2.25rem, 6vw, 3.5rem);
+    text-align: center;
+    display: grid;
+    gap: 1.15rem;
+}
+
+.ts-video-gallery__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: center;
+    padding: 0.4rem 0.95rem;
+    border-radius: 999px;
+    background: rgba(76, 110, 245, 0.12);
+    color: var(--color-olive-dark);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.78rem;
+}
+
+.ts-video-gallery__eyebrow::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent);
+}
+
+.ts-video-gallery__intro h2 {
+    margin: 0;
+    font-size: clamp(2.1rem, 4.5vw, 2.9rem);
+}
+
+.ts-video-gallery__intro p {
+    margin: 0;
+    font-size: clamp(1rem, 2.4vw, 1.1rem);
+    line-height: 1.7;
+}
+
+.ts-video-gallery__intro-description {
+    color: #000000;
+}
+
+.ts-video-gallery__stats {
+    display: grid;
+    gap: clamp(1rem, 3vw, 1.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    margin: 0 auto clamp(2rem, 6vw, 3rem);
+    max-width: 860px;
+}
+
+.ts-gallery-stat {
+    border-radius: calc(var(--radius-lg) - 8px);
+    padding: 1.5rem 1.75rem;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(237, 242, 255, 0.78));
+    box-shadow: 0 24px 52px rgba(28, 38, 59, 0.14);
+    border: 1px solid rgba(76, 110, 245, 0.12);
+    display: grid;
+    gap: 0.4rem;
+    justify-items: center;
+    text-align: center;
+}
+
+.ts-gallery-stat__value {
+    font-size: clamp(1.8rem, 3.6vw, 2.5rem);
+    font-weight: 700;
+    color: var(--color-olive-dark);
+}
+
+.ts-gallery-stat__label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.ts-gallery-stat__note {
+    font-size: 0.82rem;
+    color: var(--color-muted);
+    line-height: 1.4;
+}
+
+.ts-video-gallery__filters {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-bottom: clamp(2.25rem, 6vw, 3.1rem);
+}
+
+.ts-gallery-filter {
+    border: 1px solid rgba(76, 110, 245, 0.16);
+    background: linear-gradient(135deg, #ffffff, var(--color-accent-soft));
+    border-radius: 999px;
+    padding: 0.5rem 1.35rem;
+    font: inherit;
+    font-weight: 600;
+    color: var(--color-text);
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+.ts-gallery-filter:hover,
+.ts-gallery-filter:focus-visible {
+    outline: none;
+    border-color: rgba(76, 110, 245, 0.38);
+    background: linear-gradient(135deg, #ffffff, rgba(237, 242, 255, 0.9));
+    color: var(--color-olive-dark);
+    box-shadow: 0 16px 34px rgba(76, 110, 245, 0.18);
+    transform: translateY(-2px);
+}
+
+.ts-gallery-filter.is-active,
+.ts-gallery-filter[aria-pressed='true'] {
+    border-color: rgba(76, 110, 245, 0.55);
+    background: linear-gradient(135deg, rgba(76, 110, 245, 0.16), rgba(76, 110, 245, 0.05));
+    color: var(--color-olive-dark);
+    box-shadow: 0 18px 36px rgba(76, 110, 245, 0.18);
 }
 
 .ts-video-gallery__grid {
     display: grid;
-    gap: clamp(1.5rem, 3vw, 2.25rem);
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.8rem, 3vw, 2.6rem);
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    list-style: none;
+    padding: 0;
+    margin: 0;
 }
 
-.ts-video-gallery__grid--wall {
-    gap: clamp(1.75rem, 3.5vw, 2.75rem);
-}
-
-.ts-video-tile {
+.ts-video-card {
     position: relative;
-    border-radius: var(--radius-md);
+    border-radius: calc(var(--radius-lg) - 4px);
     overflow: hidden;
-    background: linear-gradient(135deg, rgba(246, 196, 69, 0.38), rgba(242, 153, 74, 0.24));
-    padding: clamp(0.5rem, 1vw, 0.75rem);
-    box-shadow: 0 22px 48px rgba(58, 72, 44, 0.18);
-    transition: transform 0.35s ease, box-shadow 0.35s ease;
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.96), rgba(237, 242, 255, 0.82));
+    border: 1px solid rgba(76, 110, 245, 0.12);
+    box-shadow: 0 26px 58px rgba(28, 38, 59, 0.15);
+    transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.4s ease, border-color 0.4s ease;
+    --video-card-accent: #4c6ef5;
+    --video-card-accent-soft: rgba(76, 110, 245, 0.14);
+    --video-card-accent-strong: rgba(76, 110, 245, 0.35);
+    --video-card-highlight: rgba(76, 110, 245, 0.2);
+    --video-card-preview: linear-gradient(140deg, rgba(76, 110, 245, 0.85), rgba(131, 158, 255, 0.7));
 }
 
-.ts-video-tile::before {
-    content: "";
+.ts-video-card[data-theme='finance'] {
+    --video-card-accent: #3b6dff;
+    --video-card-accent-soft: rgba(59, 109, 255, 0.12);
+    --video-card-accent-strong: rgba(59, 109, 255, 0.32);
+    --video-card-highlight: rgba(59, 109, 255, 0.18);
+    --video-card-preview: linear-gradient(140deg, rgba(59, 109, 255, 0.9), rgba(147, 176, 255, 0.7));
+}
+
+.ts-video-card[data-theme='backoffice'] {
+    --video-card-accent: #7c5cff;
+    --video-card-accent-soft: rgba(124, 92, 255, 0.14);
+    --video-card-accent-strong: rgba(124, 92, 255, 0.35);
+    --video-card-highlight: rgba(124, 92, 255, 0.2);
+    --video-card-preview: linear-gradient(140deg, rgba(124, 92, 255, 0.9), rgba(175, 153, 255, 0.7));
+}
+
+.ts-video-card[data-theme='procurement'] {
+    --video-card-accent: #0ca678;
+    --video-card-accent-soft: rgba(12, 166, 120, 0.12);
+    --video-card-accent-strong: rgba(12, 166, 120, 0.28);
+    --video-card-highlight: rgba(12, 166, 120, 0.18);
+    --video-card-preview: linear-gradient(140deg, rgba(12, 166, 120, 0.9), rgba(110, 219, 185, 0.7));
+}
+
+.ts-video-card[data-theme='hr'] {
+    --video-card-accent: #f76707;
+    --video-card-accent-soft: rgba(247, 103, 7, 0.14);
+    --video-card-accent-strong: rgba(247, 103, 7, 0.3);
+    --video-card-highlight: rgba(247, 103, 7, 0.2);
+    --video-card-preview: linear-gradient(140deg, rgba(247, 103, 7, 0.88), rgba(255, 180, 109, 0.7));
+}
+
+.ts-video-card[data-theme='support'] {
+    --video-card-accent: #22b8cf;
+    --video-card-accent-soft: rgba(34, 184, 207, 0.14);
+    --video-card-accent-strong: rgba(34, 184, 207, 0.3);
+    --video-card-highlight: rgba(34, 184, 207, 0.2);
+    --video-card-preview: linear-gradient(140deg, rgba(34, 184, 207, 0.9), rgba(148, 228, 242, 0.7));
+}
+
+.ts-video-card[data-theme='sales'] {
+    --video-card-accent: #f03e3e;
+    --video-card-accent-soft: rgba(240, 62, 62, 0.12);
+    --video-card-accent-strong: rgba(240, 62, 62, 0.3);
+    --video-card-highlight: rgba(240, 62, 62, 0.18);
+    --video-card-preview: linear-gradient(140deg, rgba(240, 62, 62, 0.88), rgba(255, 151, 151, 0.68));
+}
+
+.ts-video-card[data-theme='compliance'] {
+    --video-card-accent: #5c7cfa;
+    --video-card-accent-soft: rgba(92, 124, 250, 0.14);
+    --video-card-accent-strong: rgba(92, 124, 250, 0.32);
+    --video-card-highlight: rgba(92, 124, 250, 0.22);
+    --video-card-preview: linear-gradient(140deg, rgba(92, 124, 250, 0.9), rgba(166, 189, 255, 0.7));
+}
+
+.ts-video-card[data-theme='logistics'] {
+    --video-card-accent: #2f9e44;
+    --video-card-accent-soft: rgba(47, 158, 68, 0.14);
+    --video-card-accent-strong: rgba(47, 158, 68, 0.3);
+    --video-card-highlight: rgba(47, 158, 68, 0.2);
+    --video-card-preview: linear-gradient(140deg, rgba(47, 158, 68, 0.9), rgba(143, 214, 160, 0.7));
+}
+
+.ts-video-card[data-theme='marketing'] {
+    --video-card-accent: #ae3ec9;
+    --video-card-accent-soft: rgba(174, 62, 201, 0.14);
+    --video-card-accent-strong: rgba(174, 62, 201, 0.32);
+    --video-card-highlight: rgba(174, 62, 201, 0.2);
+    --video-card-preview: linear-gradient(140deg, rgba(174, 62, 201, 0.9), rgba(214, 137, 232, 0.7));
+}
+
+.ts-video-card__button {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 3vw, 2rem);
+    width: 100%;
+    height: 100%;
+    padding: clamp(1.75rem, 3.5vw, 2.25rem);
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+    align-items: stretch;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+.ts-video-card__button:focus-visible {
+    outline: 3px solid rgba(76, 110, 245, 0.35);
+    outline-offset: 4px;
+}
+
+.ts-video-card__preview {
+    position: relative;
+    border-radius: calc(var(--radius-lg) - 1.1rem);
+    overflow: hidden;
+    aspect-ratio: 16 / 9;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 1.2rem 1.35rem;
+    background: var(--video-card-preview);
+    color: #fff;
+}
+
+.ts-video-card__preview::before {
+    content: '';
+    position: absolute;
+    inset: 10% 35% -40% -10%;
+    background: radial-gradient(60% 80% at 20% 20%, rgba(255, 255, 255, 0.35) 0%, transparent 70%);
+    opacity: 0.65;
+    transform: rotate(-8deg);
+}
+
+.ts-video-card__preview::after {
+    content: '';
     position: absolute;
     inset: 0;
-    border-radius: inherit;
-    background: radial-gradient(circle at top, rgba(255, 255, 255, 0.35), transparent 55%);
-    opacity: 0;
-    transition: opacity 0.35s ease;
-    pointer-events: none;
+    background: linear-gradient(180deg, transparent 15%, rgba(0, 0, 0, 0.3) 100%);
+    opacity: 0.6;
 }
 
-.ts-video-tile video {
-    display: block;
-    width: 100%;
-    border-radius: calc(var(--radius-md) - clamp(0.5rem, 1vw, 0.75rem));
-    aspect-ratio: 16 / 9;
-    object-fit: cover;
-    background: #0c1014;
+.ts-video-card__badge {
+    position: relative;
+    z-index: 1;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.22);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    backdrop-filter: blur(6px);
 }
 
-.ts-video-tile:hover,
-.ts-video-tile:focus-within {
-    transform: translateY(-8px);
-    box-shadow: 0 34px 68px rgba(41, 51, 31, 0.25);
+.ts-video-card__play {
+    position: relative;
+    z-index: 1;
+    align-self: flex-end;
+    display: grid;
+    place-items: center;
+    width: 58px;
+    height: 58px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    box-shadow: 0 16px 30px rgba(0, 0, 0, 0.28);
+    transition: transform 0.35s ease, background 0.35s ease, box-shadow 0.35s ease;
 }
 
-.ts-video-tile:hover::before,
-.ts-video-tile:focus-within::before {
-    opacity: 1;
+.ts-video-card__play svg {
+    width: 24px;
+    height: 24px;
+    fill: currentColor;
+}
+
+.ts-video-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.ts-video-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.ts-video-card__tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: var(--video-card-accent-soft);
+    color: var(--color-olive-dark);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.ts-video-card__tag--tone {
+    background: rgba(255, 255, 255, 0.8);
+    color: rgba(45, 42, 38, 0.78);
+    box-shadow: inset 0 0 0 1px var(--video-card-accent-soft);
+}
+
+.ts-video-card__title {
+    margin: 0;
+    font-size: clamp(1.18rem, 2.4vw, 1.45rem);
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--color-text);
+}
+
+.ts-video-card__description {
+    margin: 0;
+    color: rgba(45, 42, 38, 0.72);
+    line-height: 1.65;
+}
+
+.ts-video-card__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.ts-video-card__meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: rgba(45, 42, 38, 0.7);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.ts-video-card__meta svg {
+    width: 18px;
+    height: 18px;
+    fill: var(--video-card-accent);
+}
+
+.ts-video-card__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: var(--color-olive-dark);
+    font-size: 0.95rem;
+    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.ts-video-card__cta svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+    transition: transform 0.3s ease;
+}
+
+.ts-video-card:hover,
+.ts-video-card:focus-within {
+    transform: translateY(-12px);
+    box-shadow: 0 32px 70px rgba(28, 38, 59, 0.2);
+    border-color: var(--video-card-accent-soft);
+}
+
+.ts-video-card:hover .ts-video-card__play,
+.ts-video-card:focus-within .ts-video-card__play {
+    background: rgba(255, 255, 255, 0.28);
+    box-shadow: 0 22px 44px rgba(0, 0, 0, 0.28);
+    transform: scale(1.08);
+}
+
+.ts-video-card:hover .ts-video-card__cta svg,
+.ts-video-card:focus-within .ts-video-card__cta svg {
+    transform: translateX(4px);
+}
+
+.ts-video-card:hover .ts-video-card__cta,
+.ts-video-card:focus-within .ts-video-card__cta {
+    color: var(--video-card-accent);
+}
+
+.ts-video-card:hover .ts-video-card__tag,
+.ts-video-card:focus-within .ts-video-card__tag {
+    background: var(--video-card-highlight);
+}
+
+@media (max-width: 720px) {
+    .ts-video-gallery__stats {
+        max-width: none;
+    }
+
+    .ts-gallery-stat {
+        padding: 1.35rem 1.5rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .ts-video-card__button {
+        padding: 1.6rem;
+        gap: 1.5rem;
+    }
+
+    .ts-video-card__preview {
+        border-radius: calc(var(--radius-lg) - 0.9rem);
+    }
 }
 
 .ts-grid {
@@ -3280,8 +3707,8 @@ body.ts-page.ts-modal-open {
     align-items: center;
     justify-content: center;
     padding: 24px;
-    background-color: rgba(33, 33, 33, 0.72);
-    backdrop-filter: blur(4px);
+    background-color: rgba(20, 24, 38, 0.62);
+    backdrop-filter: blur(10px);
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.3s ease;
@@ -3301,10 +3728,28 @@ body.ts-page.ts-modal-open {
 .ts-video-modal__dialog {
     position: relative;
     width: min(960px, 100%);
-    background-color: #0d0d0d;
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(237, 242, 255, 0.92));
     border-radius: var(--radius-md);
-    box-shadow: var(--shadow-soft);
+    border: 1px solid rgba(76, 110, 245, 0.18);
+    box-shadow: 0 42px 88px rgba(28, 38, 59, 0.35);
+    padding: clamp(1.5rem, 3vw, 2.1rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 2vw, 1.6rem);
     overflow: hidden;
+    isolation: isolate;
+}
+
+.ts-video-modal__dialog::before {
+    content: '';
+    position: absolute;
+    inset: -20% -18% auto auto;
+    width: 220px;
+    height: 220px;
+    background: radial-gradient(circle, rgba(76, 110, 245, 0.2), transparent 70%);
+    filter: blur(0.5px);
+    z-index: 0;
+    pointer-events: none;
 }
 
 .ts-video-modal__player {
@@ -3312,11 +3757,82 @@ body.ts-page.ts-modal-open {
     width: 100%;
     height: auto;
     aspect-ratio: 16 / 9;
-    background-color: #000;
+    background-color: #0f172a;
+    border-radius: calc(var(--radius-md) - 0.75rem);
+    border: 1px solid rgba(76, 110, 245, 0.22);
+    box-shadow: 0 28px 60px rgba(28, 38, 59, 0.28);
+    position: relative;
+    z-index: 1;
+}
+
+.ts-video-modal__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    color: var(--color-text);
+    position: relative;
+    z-index: 1;
+    padding-right: clamp(3.25rem, 7vw, 4.5rem);
+}
+
+.ts-video-modal__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-accent);
+    background: rgba(76, 110, 245, 0.12);
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+}
+
+.ts-video-modal__title {
+    margin: 0;
+    font-size: clamp(1.4rem, 3.2vw, 1.95rem);
+    line-height: 1.35;
+    color: var(--color-text);
+}
+
+.ts-video-modal__close {
+    position: absolute;
+    top: clamp(0.75rem, 1.5vw, 1.1rem);
+    right: clamp(0.75rem, 1.5vw, 1.1rem);
+    width: 42px;
+    height: 42px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(76, 110, 245, 0.1);
+    color: var(--color-olive-dark);
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+    z-index: 2;
+}
+
+.ts-video-modal__close span {
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.ts-video-modal__close:hover,
+.ts-video-modal__close:focus-visible {
+    outline: none;
+    background: rgba(76, 110, 245, 0.18);
+    color: var(--color-accent);
+    box-shadow: 0 14px 28px rgba(76, 110, 245, 0.22);
 }
 
 @media (max-width: 640px) {
     .ts-video-modal {
         padding: 16px;
+    }
+
+    .ts-video-modal__dialog::before {
+        width: 160px;
+        height: 160px;
     }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -372,10 +372,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const videoModal = document.querySelector('.ts-video-modal');
-    const videoTrigger = document.querySelector('[data-video-trigger]');
+    const videoTriggers = Array.from(document.querySelectorAll('[data-video-trigger]'));
 
-    if (videoModal && videoTrigger) {
+    if (videoModal && videoTriggers.length > 0) {
         const videoPlayer = videoModal.querySelector('video');
+        const videoSource = videoPlayer ? videoPlayer.querySelector('source') : null;
+        const modalTitle = videoModal.querySelector('.ts-video-modal__title');
         const closeButtons = Array.from(videoModal.querySelectorAll('[data-video-close]'));
         const dialog = videoModal.querySelector('.ts-video-modal__dialog');
         let previouslyFocusedElement = null;
@@ -390,8 +392,41 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         };
 
-        const openVideoModal = () => {
+        const setVideoContent = (trigger) => {
+            if (!videoPlayer || !(trigger instanceof HTMLElement)) {
+                return;
+            }
+
+            const videoSrc = trigger.getAttribute('data-video-src');
+            const videoType = trigger.getAttribute('data-video-type') || 'video/mp4';
+            const videoPoster = trigger.getAttribute('data-video-poster');
+            const videoTitle = trigger.getAttribute('data-video-title');
+
+            if (videoPoster) {
+                videoPlayer.setAttribute('poster', videoPoster);
+            } else {
+                videoPlayer.removeAttribute('poster');
+            }
+
+            if (videoSource) {
+                if (videoSrc) {
+                    videoSource.setAttribute('src', videoSrc);
+                }
+                videoSource.setAttribute('type', videoType);
+                videoPlayer.load();
+            } else if (videoSrc) {
+                videoPlayer.setAttribute('src', videoSrc);
+                videoPlayer.load();
+            }
+
+            if (modalTitle && videoTitle) {
+                modalTitle.textContent = videoTitle;
+            }
+        };
+
+        const openVideoModal = (trigger) => {
             previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+            setVideoContent(trigger);
             videoModal.classList.add('is-open');
             videoModal.setAttribute('aria-hidden', 'false');
             document.body.classList.add('ts-modal-open');
@@ -431,8 +466,10 @@ document.addEventListener('DOMContentLoaded', () => {
             previouslyFocusedElement = null;
         };
 
-        videoTrigger.addEventListener('click', () => {
-            openVideoModal();
+        videoTriggers.forEach((trigger) => {
+            trigger.addEventListener('click', () => {
+                openVideoModal(trigger);
+            });
         });
 
         closeButtons.forEach((button) => {

--- a/primery-rabot-robotov.html
+++ b/primery-rabot-robotov.html
@@ -51,43 +51,468 @@
     <main>
         <section class="ts-video-gallery" data-animate="section">
             <div class="ts-container">
-                <div class="ts-video-gallery__grid ts-video-gallery__grid--wall">
-                    <div class="ts-video-tile" data-animate="fade-up">
-                        <video src="assets/videos/firstvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
+                <div class="ts-video-gallery__intro" data-animate="fade-up">
+                    <span class="ts-video-gallery__eyebrow">Коллекция кейсов</span>
+                    <h2>Посмотрите, как работают наши роботы</h2>
+                    <p class="ts-video-gallery__intro-description">
+                        Собрали короткие ролики с живыми интерфейсами: от финансов и закупок до HR и клиентской поддержки.
+                        Нажмите на карточку, чтобы открыть модальное окно и внимательно рассмотреть процесс.
+                    </p>
+                </div>
 
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.1">
-                        <video src="assets/videos/secondvideo.mp4" controls preload="metadata" playsinline></video>
+                <div class="ts-video-gallery__stats" data-animate="fade-up" data-animate-delay="0.05">
+                    <div class="ts-gallery-stat">
+                        <span class="ts-gallery-stat__value">9</span>
+                        <span class="ts-gallery-stat__label">готовых сценариев</span>
+                        <span class="ts-gallery-stat__note">Покрываем финансы, продажи, HR и поддержку</span>
                     </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.2">
-                        <video src="assets/videos/thirdvideo.mp4" controls preload="metadata" playsinline></video>
+                    <div class="ts-gallery-stat">
+                        <span class="ts-gallery-stat__value">2–4 недели</span>
+                        <span class="ts-gallery-stat__label">срок запуска</span>
+                        <span class="ts-gallery-stat__note">Настраиваем робота под ваши процессы</span>
                     </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up">
-                        <video src="assets/videos/fourthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.1">
-                        <video src="assets/videos/fifthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.2">
-                        <video src="assets/videos/sixthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up">
-                        <video src="assets/videos/seventhvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.1">
-                        <video src="assets/videos/eighthvideo.mp4" controls preload="metadata" playsinline></video>
-                    </div>
-
-                    <div class="ts-video-tile" data-animate="fade-up" data-animate-delay="0.2">
-                        <video src="assets/videos/ninthvideo.mp4" controls preload="metadata" playsinline></video>
+                    <div class="ts-gallery-stat">
+                        <span class="ts-gallery-stat__value">24/7</span>
+                        <span class="ts-gallery-stat__label">работа без сбоев</span>
+                        <span class="ts-gallery-stat__note">Мониторим качество и присылаем отчёты</span>
                     </div>
                 </div>
+
+                <div class="ts-video-gallery__filters" data-animate="fade-up" data-animate-delay="0.1">
+                    <button class="ts-gallery-filter is-active" type="button" aria-pressed="true">Все кейсы</button>
+                    <button class="ts-gallery-filter" type="button" aria-pressed="false">Финансы</button>
+                    <button class="ts-gallery-filter" type="button" aria-pressed="false">Операции</button>
+                    <button class="ts-gallery-filter" type="button" aria-pressed="false">Поддержка</button>
+                    <button class="ts-gallery-filter" type="button" aria-pressed="false">Продажи</button>
+                    <button class="ts-gallery-filter" type="button" aria-pressed="false">HR</button>
+                </div>
+
+                <ul class="ts-video-gallery__grid">
+                    <li class="ts-video-card" data-theme="finance" data-animate="fade-up">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/firstvideo.mp4"
+                            data-video-title="Робот сверяет банковские выписки"
+                            aria-label="Смотреть видео «Робот сверяет банковские выписки». Длительность 0:52"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">Финансы</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">Финансы</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">Контроль платежей</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот сверяет банковские выписки</h3>
+                                <p class="ts-video-card__description">
+                                    Автоматическая выгрузка и разбор выписок, сопоставление с платежами и формирование отчётов без
+                                    ручного участия.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>0:52</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-theme="backoffice" data-animate="fade-up" data-animate-delay="0.08">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/secondvideo.mp4"
+                            data-video-title="Робот подготавливает бухгалтерскую отчётность"
+                            aria-label="Смотреть видео «Робот подготавливает бухгалтерскую отчётность». Длительность 1:04"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">Бэк-офис</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">Бэк-офис</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">Отчётность без стресса</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот подготавливает бухгалтерскую отчётность</h3>
+                                <p class="ts-video-card__description">
+                                    Сбор первичных документов, проверка показателей и создание итоговых файлов для отправки в налоговую
+                                    службу.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>1:04</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-theme="procurement" data-animate="fade-up" data-animate-delay="0.16">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/thirdvideo.mp4"
+                            data-video-title="Робот оформляет заявки на закупку"
+                            aria-label="Смотреть видео «Робот оформляет заявки на закупку». Длительность 0:47"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">Закупки</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">Закупки</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">ERP и согласования</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот оформляет заявки на закупку</h3>
+                                <p class="ts-video-card__description">
+                                    Получение запросов от менеджеров, проверка лимитов, заполнение форм и отправка на согласование в ERP.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>0:47</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-theme="hr" data-animate="fade-up" data-animate-delay="0.04">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/fourthvideo.mp4"
+                            data-video-title="Робот ведёт персональные карточки сотрудников"
+                            aria-label="Смотреть видео «Робот ведёт персональные карточки сотрудников». Длительность 0:55"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">HR</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">HR</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">Забота о сотрудниках</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот ведёт персональные карточки сотрудников</h3>
+                                <p class="ts-video-card__description">
+                                    Обновление кадровых данных, оформление отпусков и подготовка справок для сотрудников в пару кликов.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>0:55</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-theme="support" data-animate="fade-up" data-animate-delay="0.12">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/fifthvideo.mp4"
+                            data-video-title="Робот принимает обращения клиентов"
+                            aria-label="Смотреть видео «Робот принимает обращения клиентов». Длительность 0:49"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">Поддержка</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">Поддержка</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">Быстрая реакция</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот принимает обращения клиентов</h3>
+                                <p class="ts-video-card__description">
+                                    Интеллектуальный анализ писем и заявок, распределение по SLA и моментальные ответы без очередей.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>0:49</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-theme="sales" data-animate="fade-up" data-animate-delay="0.2">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/sixthvideo.mp4"
+                            data-video-title="Робот собирает отчёты о продажах"
+                            aria-label="Смотреть видео «Робот собирает отчёты о продажах». Длительность 1:02"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">Продажи</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">Продажи</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">Ежедневная аналитика</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот собирает отчёты о продажах</h3>
+                                <p class="ts-video-card__description">
+                                    Выгрузка данных из CRM, построение аналитики в Power BI и отправка подборок менеджерам к началу дня.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>1:02</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-theme="compliance" data-animate="fade-up" data-animate-delay="0.08">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/seventhvideo.mp4"
+                            data-video-title="Робот проверяет контрагентов"
+                            aria-label="Смотреть видео «Робот проверяет контрагентов». Длительность 0:58"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">Комплаенс</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">Комплаенс</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">Проверки 24/7</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот проверяет контрагентов</h3>
+                                <p class="ts-video-card__description">
+                                    Мониторинг реестров и санкционных списков, сбор выписок и создание заключений по каждой компании.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>0:58</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-theme="logistics" data-animate="fade-up" data-animate-delay="0.16">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/eighthvideo.mp4"
+                            data-video-title="Робот управляет складскими остатками"
+                            aria-label="Смотреть видео «Робот управляет складскими остатками». Длительность 0:54"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">Логистика</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">Логистика</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">Запасы под контролем</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот управляет складскими остатками</h3>
+                                <p class="ts-video-card__description">
+                                    Контроль запасов, планирование дозагрузки и уведомления ответственным при риске дефицита.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>0:54</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+
+                    <li class="ts-video-card" data-theme="marketing" data-animate="fade-up" data-animate-delay="0.24">
+                        <button
+                            class="ts-video-card__button"
+                            type="button"
+                            data-video-trigger
+                            data-video-src="assets/videos/ninthvideo.mp4"
+                            data-video-title="Робот формирует персональные предложения"
+                            aria-label="Смотреть видео «Робот формирует персональные предложения». Длительность 1:08"
+                        >
+                            <span class="ts-video-card__preview" aria-hidden="true">
+                                <span class="ts-video-card__badge">Маркетинг</span>
+                                <span class="ts-video-card__play" role="presentation">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M8 5v14l11-7z" fill="currentColor"></path>
+                                    </svg>
+                                </span>
+                            </span>
+                            <div class="ts-video-card__body">
+                                <div class="ts-video-card__tags">
+                                    <span class="ts-video-card__tag">Маркетинг</span>
+                                    <span class="ts-video-card__tag ts-video-card__tag--tone">Персональные кампании</span>
+                                </div>
+                                <h3 class="ts-video-card__title">Робот формирует персональные предложения</h3>
+                                <p class="ts-video-card__description">
+                                    Анализ поведения клиентов, сегментация и автоматическая отправка писем с персональными офферами.
+                                </p>
+                                <div class="ts-video-card__footer">
+                                    <span class="ts-video-card__meta">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path
+                                                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm.75-8.44 2.72 1.63-.75 1.23L11 12.4V7h1.5z"
+                                                fill="currentColor"
+                                            ></path>
+                                        </svg>
+                                        <span>1:08</span>
+                                    </span>
+                                    <span class="ts-video-card__cta">
+                                        Смотреть кейс
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M8.59 5.59 13.17 10H5v1.5h8.17l-4.58 4.41L10.5 17l6.5-6.5L10.5 4z" fill="currentColor"></path>
+                                        </svg>
+                                    </span>
+                                </div>
+                            </div>
+                        </button>
+                    </li>
+                </ul>
             </div>
         </section>
     </main>
@@ -134,6 +559,23 @@
             <p><a href="politika-konfidenczialnosti.html">Политика конфиденциальности</a></p>
         </div>
     </footer>
+
+    <div class="ts-video-modal" id="ts-video-modal" aria-hidden="true" role="dialog" aria-modal="true">
+        <div class="ts-video-modal__backdrop" data-video-close></div>
+        <div class="ts-video-modal__dialog" role="document">
+            <button class="ts-video-modal__close" type="button" data-video-close aria-label="Закрыть видео">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <div class="ts-video-modal__header">
+                <span class="ts-video-modal__eyebrow">Видео-демонстрация</span>
+                <h2 class="ts-video-modal__title">Робот сверяет банковские выписки</h2>
+            </div>
+            <video class="ts-video-modal__player" controls preload="metadata">
+                <source src="assets/videos/firstvideo.mp4" type="video/mp4" />
+                Ваш браузер не поддерживает воспроизведение видео.
+            </video>
+        </div>
+    </div>
 
     <script src="assets/js/main.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- add a dedicated class to the gallery intro paragraph and force a solid black color for the descriptive copy
- pad the video modal header so the eyebrow label no longer overlaps the close control

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e37d8f9b8c8330bf5f10673cb5f890