### PR TITLE
Fix navbar layout on client cases page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -262,9 +262,20 @@ body.ts-page.ts-modal-open {
 
 .ts-subpage-hero {
     position: relative;
-    padding: clamp(3.5rem, 7vw, 6rem) 0 clamp(2.5rem, 6vw, 4.5rem);
     background: linear-gradient(135deg, rgba(245, 241, 227, 0.95) 0%, rgba(246, 196, 69, 0.24) 50%, rgba(242, 153, 74, 0.22) 100%);
     overflow: hidden;
+}
+
+.ts-subpage-hero__inner {
+    position: relative;
+    z-index: 1;
+    padding: clamp(3.5rem, 7vw, 6rem) 0 clamp(2.5rem, 6vw, 4.5rem);
+}
+
+.ts-subpage-hero__nav {
+    position: sticky;
+    top: 0;
+    z-index: 12;
 }
 
 .ts-subpage-hero__overlay {

--- a/primery-rabot-robotov.html
+++ b/primery-rabot-robotov.html
@@ -15,35 +15,40 @@
 </head>
 <body class="ts-page ts-page--gallery">
     <header class="ts-subpage-hero" data-animate="hero">
-        <div class="ts-subpage-hero__overlay"></div>
-        <div class="ts-container">
-            <nav class="ts-nav" aria-label="Главная навигация">
-                <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
-                <input id="ts-nav-toggle" class="ts-nav__checkbox" type="checkbox" aria-hidden="true" />
-                <label for="ts-nav-toggle" class="ts-nav__toggle" aria-label="Открыть меню">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </label>
-                <ul class="ts-nav__links">
-                    <li><a href="index.html#ts-services">Услуги</a></li>
-                    <li><a href="index.html#ts-portfolio">Портфолио</a></li>
-                    <li><a href="o-nas.html">О нас</a></li>
-                    <li><a href="index.html#ts-pricing">Цены</a></li>
-                    <li><a href="index.html#ts-faq">FAQ</a></li>
-                    <li><a href="kontakty.html">Контакты</a></li>
-                    <li><a href="primery-rabot-robotov.html" aria-current="page">Кейсы наших клиентов</a></li>
-                </ul>
-                <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Записаться на демо</a>
-            </nav>
-
-            <div class="ts-subpage-hero__content" data-animate="fade-up">
-                <span class="ts-subpage-hero__eyebrow">Видео-галерея</span>
-                <h1>Кейсы наших клиентов</h1>
-                <p>
-                    Посмотрите короткие ролики о том, как интеллектуальные роботы выполняют рутинные операции, ускоряя работу команд и
-                    повышая точность процессов.
-                </p>
+        <div class="ts-subpage-hero__nav ts-subheader__nav">
+            <div class="ts-container">
+                <nav class="ts-nav" aria-label="Главная навигация">
+                    <a class="ts-logo" href="index.html#ts-home">Technostation: AI-RPA</a>
+                    <input id="ts-nav-toggle" class="ts-nav__checkbox" type="checkbox" aria-hidden="true" />
+                    <label for="ts-nav-toggle" class="ts-nav__toggle" aria-label="Открыть меню">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </label>
+                    <ul class="ts-nav__links">
+                        <li><a href="index.html#ts-services">Услуги</a></li>
+                        <li><a href="index.html#ts-portfolio">Портфолио</a></li>
+                        <li><a href="o-nas.html">О нас</a></li>
+                        <li><a href="index.html#ts-pricing">Цены</a></li>
+                        <li><a href="index.html#ts-faq">FAQ</a></li>
+                        <li><a href="kontakty.html">Контакты</a></li>
+                        <li><a href="primery-rabot-robotov.html" aria-current="page">Кейсы наших клиентов</a></li>
+                    </ul>
+                    <a class="ts-nav__cta" href="kontakty.html#ts-contact-form">Записаться на демо</a>
+                </nav>
+            </div>
+        </div>
+        <div class="ts-subpage-hero__overlay" aria-hidden="true"></div>
+        <div class="ts-subpage-hero__inner">
+            <div class="ts-container">
+                <div class="ts-subpage-hero__content" data-animate="fade-up">
+                    <span class="ts-subpage-hero__eyebrow">Видео-галерея</span>
+                    <h1>Кейсы наших клиентов</h1>
+                    <p>
+                        Посмотрите короткие ролики о том, как интеллектуальные роботы выполняют рутинные операции, ускоряя работу команд и
+                        повышая точность процессов.
+                    </p>
+                </div>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- wrap the cases page navigation in the shared sticky subheader container so it matches other pages
- tweak the hero styles to move spacing into a new inner wrapper while keeping the navigation flush to the top

## Testing
- Not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68e393c9f56c8330a31d1b5ade18a572