### PR TITLE
Remove placeholder tokens from portfolio SVG text

### DIFF
--- a/assets/images/portfolio-1.svg
+++ b/assets/images/portfolio-1.svg
@@ -10,5 +10,5 @@
   <rect x="92" y="96" width="280" height="32" rx="16" fill="rgba(85,107,47,0.7)" />
   <rect x="92" y="144" width="220" height="24" rx="12" fill="rgba(255,255,255,0.7)" />
   <circle cx="420" cy="250" r="54" fill="rgba(85,107,47,0.2)" />
-  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс ${i}</text>
+  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс</text>
 </svg>

--- a/assets/images/portfolio-2.svg
+++ b/assets/images/portfolio-2.svg
@@ -10,5 +10,5 @@
   <rect x="92" y="96" width="280" height="32" rx="16" fill="rgba(85,107,47,0.7)" />
   <rect x="92" y="144" width="220" height="24" rx="12" fill="rgba(255,255,255,0.7)" />
   <circle cx="420" cy="250" r="54" fill="rgba(85,107,47,0.2)" />
-  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс ${i}</text>
+  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс</text>
 </svg>

--- a/assets/images/portfolio-3.svg
+++ b/assets/images/portfolio-3.svg
@@ -10,5 +10,5 @@
   <rect x="92" y="96" width="280" height="32" rx="16" fill="rgba(85,107,47,0.7)" />
   <rect x="92" y="144" width="220" height="24" rx="12" fill="rgba(255,255,255,0.7)" />
   <circle cx="420" cy="250" r="54" fill="rgba(85,107,47,0.2)" />
-  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс ${i}</text>
+  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс</text>
 </svg>

--- a/assets/images/portfolio-4.svg
+++ b/assets/images/portfolio-4.svg
@@ -10,5 +10,5 @@
   <rect x="92" y="96" width="280" height="32" rx="16" fill="rgba(85,107,47,0.7)" />
   <rect x="92" y="144" width="220" height="24" rx="12" fill="rgba(255,255,255,0.7)" />
   <circle cx="420" cy="250" r="54" fill="rgba(85,107,47,0.2)" />
-  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс ${i}</text>
+  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс</text>
 </svg>

--- a/assets/images/portfolio-5.svg
+++ b/assets/images/portfolio-5.svg
@@ -10,5 +10,5 @@
   <rect x="92" y="96" width="280" height="32" rx="16" fill="rgba(85,107,47,0.7)" />
   <rect x="92" y="144" width="220" height="24" rx="12" fill="rgba(255,255,255,0.7)" />
   <circle cx="420" cy="250" r="54" fill="rgba(85,107,47,0.2)" />
-  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс ${i}</text>
+  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс</text>
 </svg>

--- a/assets/images/portfolio-6.svg
+++ b/assets/images/portfolio-6.svg
@@ -10,5 +10,5 @@
   <rect x="92" y="96" width="280" height="32" rx="16" fill="rgba(85,107,47,0.7)" />
   <rect x="92" y="144" width="220" height="24" rx="12" fill="rgba(255,255,255,0.7)" />
   <circle cx="420" cy="250" r="54" fill="rgba(85,107,47,0.2)" />
-  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс ${i}</text>
+  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс</text>
 </svg>

--- a/assets/images/portfolio-7.svg
+++ b/assets/images/portfolio-7.svg
@@ -10,5 +10,5 @@
   <rect x="92" y="96" width="280" height="32" rx="16" fill="rgba(85,107,47,0.7)" />
   <rect x="92" y="144" width="220" height="24" rx="12" fill="rgba(255,255,255,0.7)" />
   <circle cx="420" cy="250" r="54" fill="rgba(85,107,47,0.2)" />
-  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс ${i}</text>
+  <text x="60" y="290" font-family="'Manrope', sans-serif" font-size="52" font-weight="700" fill="#3C4A1F">Кейс</text>
 </svg>


### PR DESCRIPTION
## Summary
- remove the `${i}` placeholder from all portfolio SVG images so the displayed label is clean

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e60b10a69c833083a05fb379bbfacf