### PR TITLE
Hide carousel hint once user interacts

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -144,7 +144,9 @@ body.ts-page.ts-modal-open {
     .ts-floating-cta::after,
     .ts-subheader__scroll-hint,
     .ts-subheader__scroll-icon,
-    .ts-subheader__scroll-dot {
+    .ts-subheader__scroll-dot,
+    .ts-usecases__grid::after,
+    .ts-advantages__grid::after {
         animation: none !important;
         transition: none !important;
     }
@@ -209,6 +211,24 @@ body.ts-page.ts-modal-open {
         opacity: 0;
         transform: translateY(26px);
         box-shadow: 0 0 0 0 rgba(246, 196, 69, 0);
+    }
+}
+
+@keyframes ts-carousel-hint {
+    0%,
+    100% {
+        transform: translate3d(0, -50%, 0);
+        opacity: 0.45;
+    }
+    35% {
+        opacity: 1;
+    }
+    55% {
+        transform: translate3d(8px, -50%, 0);
+        opacity: 0.75;
+    }
+    80% {
+        opacity: 0.35;
     }
 }
 
@@ -1265,6 +1285,16 @@ body.ts-page--gallery {
     margin: 0;
     color: var(--color-muted);
     line-height: 1.65;
+}
+
+.ts-usecases__grid,
+.ts-advantages__grid {
+    scrollbar-width: none;
+}
+
+.ts-usecases__grid::-webkit-scrollbar,
+.ts-advantages__grid::-webkit-scrollbar {
+    display: none;
 }
 
 .ts-usecase-card:hover,
@@ -3453,6 +3483,89 @@ body.ts-page--gallery {
         height: 120px;
     }
 
+    .ts-hero__content {
+        gap: 2.25rem;
+    }
+
+    .ts-hero__text h1 {
+        font-size: clamp(2.2rem, 6.5vw, 2.8rem);
+    }
+
+    .ts-hero__text p {
+        font-size: 1rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .ts-hero__actions {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.75rem;
+    }
+
+    .ts-hero__actions .ts-button {
+        width: 100%;
+    }
+
+    .ts-cta-strip .ts-container {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: left;
+    }
+
+    .ts-cta-strip__content {
+        text-align: left;
+    }
+
+    .ts-usecases,
+    .ts-services,
+    .ts-metrics,
+    .ts-overview,
+    .ts-portfolio,
+    .ts-pricing,
+    .ts-team,
+    .ts-blog {
+        padding: 3.25rem 0;
+    }
+
+    .ts-metrics__wrapper {
+        padding: 2.25rem;
+    }
+
+    .ts-metrics__stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .ts-grid--overview {
+        grid-template-columns: 1fr;
+        gap: 2rem;
+    }
+
+    .ts-portfolio__detail {
+        padding: clamp(1.6rem, 5vw, 2rem);
+    }
+
+    .ts-portfolio__panel {
+        gap: 1.5rem;
+    }
+
+    .ts-portfolio__panel-media {
+        justify-self: center;
+    }
+
+    .ts-grid--pricing {
+        gap: 1.5rem;
+    }
+
+    .ts-contact,
+    .ts-contact-qr,
+    .ts-calculator__section {
+        padding: 3.25rem 0;
+    }
+
+    .ts-contact__form {
+        padding: 2rem;
+    }
+
 }
 
 @media (max-width: 640px) {
@@ -3517,6 +3630,17 @@ body.ts-page--gallery {
 
     .ts-nav__checkbox:checked ~ .ts-nav__links {
         transform: translateY(0);
+    }
+
+    .ts-services__list,
+    .ts-portfolio__list {
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .ts-services__item,
+    .ts-portfolio__item {
+        scroll-snap-align: start;
     }
 
     .ts-nav__checkbox:checked + .ts-nav__toggle span:nth-child(1) {
@@ -3656,6 +3780,176 @@ body.ts-page--gallery {
     }
 }
 
+@media (max-width: 768px) {
+    .ts-usecases__grid,
+    .ts-advantages__grid {
+        grid-auto-flow: column;
+        grid-auto-columns: minmax(240px, 82vw);
+        grid-template-columns: none;
+        overflow-x: auto;
+        overflow-y: hidden;
+        padding-bottom: 0.75rem;
+        scroll-snap-type: x proximity;
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior-x: contain;
+        touch-action: pan-x;
+        gap: 1rem;
+    }
+
+    .ts-usecases__grid {
+        margin-inline: -0.75rem;
+        padding-inline: 0.75rem;
+        scroll-padding-inline: 0.75rem;
+        margin-left: -0.75rem;
+        margin-right: -0.75rem;
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+    }
+
+    .ts-usecase-card,
+    .ts-advantage {
+        scroll-snap-align: start;
+    }
+
+    .ts-usecases__grid,
+    .ts-advantages__grid {
+        position: relative;
+    }
+
+    .ts-usecases__grid::after,
+    .ts-advantages__grid::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        right: 0.35rem;
+        transform: translate3d(0, -50%, 0);
+        width: 2.6rem;
+        height: 2.6rem;
+        border-radius: 999px;
+        background: radial-gradient(circle at center, rgba(255, 255, 255, 0.95) 0%, rgba(245, 241, 227, 0.92) 55%, rgba(246, 196, 69, 0.6) 100%);
+        box-shadow: 0 12px 28px rgba(60, 74, 31, 0.22);
+        pointer-events: none;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%2355622b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='8 4 16 12 8 20'/%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 16px 16px;
+        animation: ts-carousel-hint 2.6s ease-in-out infinite;
+        opacity: 0.9;
+        transition: opacity 0.35s ease, visibility 0.35s ease;
+    }
+
+    .ts-usecases__grid:active::after,
+    .ts-usecases__grid:focus-within::after,
+    .ts-usecases__grid:hover::after,
+    .ts-advantages__grid:active::after,
+    .ts-advantages__grid:focus-within::after,
+    .ts-advantages__grid:hover::after {
+        opacity: 0;
+    }
+
+    .ts-usecases__grid.ts-carousel-hint-hidden::after,
+    .ts-advantages__grid.ts-carousel-hint-hidden::after {
+        opacity: 0;
+        visibility: hidden;
+        animation: none;
+    }
+
+    .ts-usecase-card {
+        min-height: 100%;
+        padding: 1.75rem 1.5rem;
+    }
+
+    .ts-usecase-card__index {
+        width: 2.6rem;
+        height: 2.6rem;
+        font-size: 0.95rem;
+    }
+
+    .ts-usecase-card__content h3 {
+        font-size: 1.05rem;
+    }
+
+    .ts-usecase-card__content p {
+        font-size: 0.95rem;
+        line-height: 1.55;
+    }
+
+    .ts-advantages__grid {
+        grid-auto-columns: minmax(260px, 85vw);
+        margin-inline: -1rem;
+        padding-inline: 1rem;
+        scroll-padding-inline: 1rem;
+        gap: 1.1rem;
+        margin-left: -1rem;
+        margin-right: -1rem;
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    .ts-advantage {
+        min-height: 100%;
+        padding: 1.85rem 1.5rem;
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+
+    .ts-advantage__icon {
+        width: 3rem;
+        height: 3rem;
+        justify-self: flex-start;
+    }
+
+    .ts-advantage__content h3 {
+        font-size: 1.05rem;
+    }
+
+    .ts-advantage__content p {
+        font-size: 0.95rem;
+        line-height: 1.55;
+    }
+
+    .ts-grid--team {
+        justify-items: center;
+    }
+
+    .ts-team-card {
+        justify-items: center;
+        text-align: center;
+    }
+
+    .ts-team-card img {
+        width: min(100%, 240px);
+        height: auto;
+        object-fit: contain;
+    }
+
+    .ts-pricing {
+        position: relative;
+        display: block;
+    }
+
+    .has-animations .ts-pricing[data-animate],
+    .has-animations .ts-pricing [data-animate] {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+@media (max-width: 540px) {
+    .ts-usecases__grid,
+    .ts-advantages__grid {
+        grid-auto-columns: minmax(80vw, 1fr);
+    }
+
+    .ts-usecase-card {
+        padding: 1.6rem 1.25rem;
+    }
+
+    .ts-advantage {
+        padding: 1.6rem 1.25rem;
+    }
+}
+
 @media (max-width: 640px) {
     .ts-hero {
         padding: 0 0 3.5rem;
@@ -3683,7 +3977,89 @@ body.ts-page--gallery {
     .ts-team-card,
     .ts-blog-card,
     .ts-contact__form {
+        padding: 1.6rem;
+    }
+
+    .ts-usecase-card {
+        grid-template-columns: 1fr;
+        padding: 1.5rem;
+        gap: 0.9rem;
+    }
+
+    .ts-usecase-card__index {
+        margin-bottom: 0.35rem;
+    }
+
+    .ts-usecase-card__content h3 {
+        font-size: 1.05rem;
+    }
+
+    .ts-metrics__wrapper {
         padding: 1.75rem;
+    }
+
+    .ts-metrics__stats {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .ts-metrics__stats article {
+        padding: 1.4rem 1.6rem;
+    }
+
+    .ts-portfolio__panel-body {
+        gap: 1.2rem;
+    }
+
+    .ts-portfolio__panel-media {
+        max-width: 200px;
+    }
+
+    .ts-price-card {
+        gap: 1.1rem;
+    }
+
+    .ts-price-card img {
+        width: 48px;
+        height: 48px;
+    }
+
+    .ts-price-card ul {
+        padding-left: 1rem;
+    }
+
+    .ts-team-card {
+        gap: 0.65rem;
+        padding: 1.5rem 1.35rem 1.6rem;
+    }
+
+    .ts-blog-card {
+        gap: 1rem;
+    }
+
+    .ts-contact__form {
+        gap: 1.5rem;
+    }
+
+    .ts-form-grid {
+        gap: 1.1rem;
+    }
+
+    .ts-form-checkbox {
+        font-size: 0.9rem;
+        align-items: flex-start;
+    }
+
+    .ts-footer {
+        padding: 3.25rem 0 0;
+    }
+
+    .ts-grid--footer {
+        gap: 1.75rem;
+    }
+
+    .ts-footer__socials {
+        flex-wrap: wrap;
     }
 
     .ts-subpage-hero {
@@ -3702,9 +4078,17 @@ body.ts-page--gallery {
         border-radius: calc(var(--radius-md) - 0.4rem);
     }
 
-    .ts-team-card img,
+    .ts-blog-card > a {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.75rem 1rem 0;
+    }
+
     .ts-blog-card img {
-        height: 180px;
+        height: auto;
+        width: min(100%, 320px);
+        object-fit: contain;
     }
 
     .ts-footer__bottom {
@@ -4154,5 +4538,74 @@ body.ts-page--gallery {
     .ts-cta-strip__actions .ts-button {
         width: 100%;
         justify-content: center;
+    }
+
+    .ts-container {
+        width: min(96vw, 520px);
+    }
+
+    .ts-button {
+        padding: 0.75rem 1.35rem;
+        font-size: 0.95rem;
+    }
+
+    .ts-hero__text h1 {
+        font-size: clamp(2rem, 8vw, 2.4rem);
+    }
+
+    .ts-cta-strip .ts-container {
+        padding: 1.75rem;
+    }
+
+    .ts-cta-strip__content h2 {
+        font-size: 1.45rem;
+    }
+
+    .ts-usecase-card {
+        padding: 1.35rem;
+    }
+
+    .ts-metrics__wrapper {
+        padding: 1.5rem;
+    }
+
+    .ts-price-card {
+        padding: 1.4rem 1.3rem;
+    }
+
+    .ts-team-card {
+        padding: 1.35rem 1.25rem 1.5rem;
+    }
+
+    .ts-team-card img {
+        width: min(72vw, 220px);
+        height: auto;
+        object-fit: contain;
+    }
+
+    .ts-blog-card {
+        padding-bottom: 1.1rem;
+    }
+
+    .ts-blog-card > a {
+        padding: 0.75rem 0.85rem 0;
+    }
+
+    .ts-blog-card img {
+        height: auto;
+        width: min(100%, 300px);
+    }
+
+    .ts-contact__form {
+        padding: 1.4rem;
+    }
+
+    .ts-form-field input,
+    .ts-form-field textarea {
+        padding: 0.75rem 0.9rem;
+    }
+
+    .ts-footer__bottom {
+        gap: 0.75rem;
     }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,6 +9,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const scrollHints = document.querySelectorAll('.ts-subheader__scroll-hint');
     const floatingCta = document.querySelector('.ts-floating-cta');
     const isSubpage = document.body.classList.contains('ts-subpage');
+    const carouselContainers = Array.from(
+        document.querySelectorAll('.ts-usecases__grid, .ts-advantages__grid'),
+    );
     let scrollTicking = false;
 
     const addMediaQueryListener = (mediaQueryList, callback) => {
@@ -77,6 +80,43 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     };
+
+    const markCarouselHintHidden = (container) => {
+        if (!container.classList.contains('ts-carousel-hint-hidden')) {
+            container.classList.add('ts-carousel-hint-hidden');
+        }
+    };
+
+    carouselContainers.forEach((container) => {
+        if (container.scrollWidth <= container.clientWidth + 1) {
+            markCarouselHintHidden(container);
+            return;
+        }
+
+        const onCarouselScroll = () => {
+            if (container.scrollLeft > 4) {
+                markCarouselHintHidden(container);
+                container.removeEventListener('scroll', onCarouselScroll);
+            }
+        };
+
+        container.addEventListener('scroll', onCarouselScroll, { passive: true });
+
+        const onPointerIntent = () => {
+            markCarouselHintHidden(container);
+            container.removeEventListener('touchstart', onPointerIntent);
+            container.removeEventListener('mousedown', onPointerIntent);
+        };
+
+        container.addEventListener('touchstart', onPointerIntent, { passive: true });
+        container.addEventListener('mousedown', onPointerIntent);
+
+        container.addEventListener('keydown', (event) => {
+            if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+                markCarouselHintHidden(container);
+            }
+        });
+    });
 
     const onScroll = () => {
         if (scrollTicking) {

--- a/kalkulyator-effektivnosti.html
+++ b/kalkulyator-effektivnosti.html
@@ -285,6 +285,26 @@
             }
         }
 
+        @media (max-width: 820px) {
+            .ts-calculator--enhanced .ts-calculator__card {
+                padding: 2rem;
+                gap: 1.5rem;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__process {
+                padding: 1.25rem;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__actions .ts-button {
+                width: 100%;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__card-header h2 {
+                font-size: 1.4rem;
+                line-height: 1.3;
+            }
+        }
+
         @media (max-width: 720px) {
             .ts-calculator__error-grid {
                 grid-template-columns: 1fr;
@@ -296,6 +316,44 @@
 
             .ts-calculator--enhanced .ts-calculator__actions {
                 flex-direction: column;
+            }
+        }
+
+        @media (max-width: 560px) {
+            .ts-calculator--enhanced .ts-calculator__card {
+                padding: 1.4rem;
+                gap: 1.25rem;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__process {
+                padding: 1.1rem;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__field input,
+            .ts-calculator--enhanced .ts-calculator__field select {
+                padding: 0.75rem 0.85rem;
+                font-size: 0.95rem;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__summary {
+                padding: 1.25rem;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__result {
+                padding: 1rem;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__result-value {
+                font-size: 1.35rem;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__process-number {
+                width: 100%;
+                justify-content: center;
+            }
+
+            .ts-calculator--enhanced .ts-calculator__card-header h2 {
+                font-size: 1.3rem;
             }
         }
     </style>
@@ -486,6 +544,15 @@
     <script>
         let processes = [];
         let processCounter = 0;
+
+        function scrollResultsIntoView() {
+            if (window.matchMedia('(max-width: 768px)').matches) {
+                const resultCard = document.querySelector('.ts-calculator__card--results');
+                if (resultCard) {
+                    resultCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            }
+        }
 
         function addProcess() {
             processCounter += 1;
@@ -693,6 +760,7 @@
                 warningEl.hidden = false;
                 breakdownEl.hidden = true;
                 badgeContainer.innerHTML = '';
+                scrollResultsIntoView();
                 return;
             }
 
@@ -772,6 +840,7 @@
                 badgeHTML += '<span class="ts-calculator__badge ts-calculator__badge--accent">🎯 Эффект масштаба: экономия на лицензии!</span>';
             }
             badgeContainer.innerHTML = badgeHTML;
+            scrollResultsIntoView();
         }
 
         addProcess();


### PR DESCRIPTION
## Summary
- hide the mobile carousel swipe indicator after the user interacts or scrolls so it no longer overlays later cards
- add CSS transitions and animation stop to fully remove the hint once hidden

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e628023f5c83309f7ec9e2b285d9bc