### PR TITLE
Improve mobile carousel affordances

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3645,6 +3645,81 @@ body.ts-page--gallery {
         scroll-snap-align: start;
     }
 
+    .ts-carousel-container {
+        position: relative;
+    }
+
+    .ts-carousel-container::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        width: clamp(2rem, 10vw, 3.75rem);
+        background: linear-gradient(270deg, rgba(255, 255, 255, 0.97) 0%, rgba(255, 255, 255, 0) 70%);
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.35s ease;
+        z-index: 4;
+    }
+
+    .ts-carousel-container:not(.ts-carousel-hint-hidden)::after {
+        opacity: 1;
+    }
+
+    .ts-carousel-container > .ts-carousel-hint {
+        position: absolute;
+        top: 50%;
+        right: clamp(0.75rem, 4vw, 1.5rem);
+        transform: translate3d(0, -50%, 0);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.45rem 0.9rem;
+        border-radius: 999px;
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(246, 196, 69, 0.92) 100%);
+        box-shadow: 0 14px 32px rgba(60, 74, 31, 0.25);
+        color: #2f3b21;
+        font-size: 0.78rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        pointer-events: none;
+        z-index: 6;
+        opacity: 1;
+        transition: opacity 0.35s ease, transform 0.35s ease, visibility 0.35s ease;
+        white-space: nowrap;
+    }
+
+    .ts-carousel-hint__text {
+        line-height: 1;
+        white-space: nowrap;
+    }
+
+    .ts-carousel-container > .ts-carousel-hint .ts-carousel-hint__arrow {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.4rem;
+        height: 1.4rem;
+        border-radius: 999px;
+        background: rgba(52, 63, 33, 0.95);
+        color: #ffffff;
+        font-size: 0.85rem;
+        line-height: 1;
+        animation: ts-carousel-hint 2.4s ease-in-out infinite;
+    }
+
+    .ts-carousel-container.ts-carousel-hint-hidden > .ts-carousel-hint {
+        opacity: 0;
+        visibility: hidden;
+        transform: translate3d(0, -50%, 0) scale(0.9);
+    }
+
+    .ts-carousel-container.ts-carousel-hint-hidden::after {
+        opacity: 0;
+    }
+
     .ts-nav__checkbox:checked + .ts-nav__toggle span:nth-child(1) {
         transform: translateY(9px) rotate(45deg);
     }
@@ -3811,60 +3886,6 @@ body.ts-page--gallery {
     .ts-usecase-card,
     .ts-advantage {
         scroll-snap-align: start;
-    }
-
-    .ts-usecases__grid,
-    .ts-advantages__grid {
-        position: relative;
-    }
-
-    .ts-carousel-hint {
-        position: absolute;
-        top: 50%;
-        right: clamp(0.45rem, 2vw, 1rem);
-        transform: translate3d(0, -50%, 0);
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-        padding: 0.45rem 0.9rem;
-        border-radius: 999px;
-        background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(246, 196, 69, 0.92) 100%);
-        box-shadow: 0 14px 32px rgba(60, 74, 31, 0.25);
-        color: #2f3b21;
-        font-size: 0.78rem;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        text-transform: uppercase;
-        pointer-events: none;
-        z-index: 6;
-        opacity: 1;
-        transition: opacity 0.35s ease, transform 0.35s ease, visibility 0.35s ease;
-    }
-
-    .ts-carousel-hint__text {
-        line-height: 1;
-        white-space: nowrap;
-    }
-
-    .ts-carousel-hint__arrow {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 1.4rem;
-        height: 1.4rem;
-        border-radius: 999px;
-        background: rgba(52, 63, 33, 0.95);
-        color: #ffffff;
-        font-size: 0.85rem;
-        line-height: 1;
-        animation: ts-carousel-hint 2.4s ease-in-out infinite;
-    }
-
-    .ts-usecases__grid.ts-carousel-hint-hidden .ts-carousel-hint,
-    .ts-advantages__grid.ts-carousel-hint-hidden .ts-carousel-hint {
-        opacity: 0;
-        visibility: hidden;
-        transform: translate3d(0, -50%, 0) scale(0.9);
     }
 
     .ts-usecase-card {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,9 +10,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const floatingCta = document.querySelector('.ts-floating-cta');
     const isSubpage = document.body.classList.contains('ts-subpage');
     const carouselContainers = Array.from(
-        document.querySelectorAll('.ts-usecases__grid, .ts-advantages__grid'),
+        document.querySelectorAll(
+            '.ts-usecases__grid, .ts-advantages__grid, .ts-services__list, .ts-portfolio__list',
+        ),
     );
-    const carouselHintMedia = window.matchMedia('(max-width: 768px)');
+    const carouselHintMedia = window.matchMedia('(max-width: 960px)');
     let scrollTicking = false;
 
     const addMediaQueryListener = (mediaQueryList, callback) => {
@@ -594,7 +596,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const label = document.createElement('span');
         label.className = 'ts-carousel-hint__text';
-        label.textContent = 'Свайпните';
+        label.textContent = 'Свайпайте';
 
         const arrow = document.createElement('span');
         arrow.className = 'ts-carousel-hint__arrow';

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
                     <h2 id="ts-usecases-title">Применение интеллектуальных роботов по отделам</h2>
                     <p>Посмотрите, какие задачи мы закрываем уже на старте проектов.</p>
                 </div>
-                <div class="ts-usecases__grid">
+                <div class="ts-usecases__grid ts-carousel-container">
                     <article class="ts-usecase-card" data-animate="lift" data-animate-delay="0">
                         <span class="ts-usecase-card__index" aria-hidden="true">01</span>
                         <div class="ts-usecase-card__content">
@@ -137,7 +137,7 @@
                 </div>
 
                 <div class="ts-services__layout" data-animate="fade-up">
-                    <div class="ts-services__list" role="tablist" aria-label="Услуги Technostation">
+                    <div class="ts-services__list ts-carousel-container" role="tablist" aria-label="Услуги Technostation">
                         <button
                             class="ts-services__item is-active"
                             data-index="01"
@@ -363,7 +363,7 @@
                     <h2>Конкурентные преимущества Technostation</h2>
                     <p>Сосредоточились на ключевых факторах, которые дают быстрый эффект клиентам.</p>
                 </div>
-                <div class="ts-advantages__grid">
+                <div class="ts-advantages__grid ts-carousel-container">
                     <article class="ts-advantage" data-animate="lift" data-animate-delay="0">
                         <div class="ts-advantage__icon" aria-hidden="true">
                             <span class="ts-advantage__spark"></span>
@@ -434,7 +434,7 @@
                     <h2>Кейсы наших клиентов</h2>
                 </div>
                 <div class="ts-portfolio__layout">
-                    <div class="ts-portfolio__list" role="tablist" aria-label="Кейсы Technostation">
+                    <div class="ts-portfolio__list ts-carousel-container" role="tablist" aria-label="Кейсы Technostation">
                         <button
                             class="ts-portfolio__item is-active"
                             type="button"


### PR DESCRIPTION
## Summary
- add a reusable `ts-carousel-container` marker to home page carousels so that swipe hints can be attached
- extend the carousel hint script to cover services and portfolio lists on viewports up to 960px wide and update the hint copy
- style the shared carousel hint with a gradient edge and floating badge to make the swipe interaction obvious on mobile

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e6452b1d508330a07041b9bb43613f