### PR TITLE
Remove mobile carousel hint and preload cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -214,26 +214,6 @@ body.ts-page.ts-modal-open {
     }
 }
 
-@keyframes ts-carousel-hint {
-    0%,
-    100% {
-        transform: translateX(0);
-        opacity: 0.9;
-    }
-    40% {
-        transform: translateX(8px);
-        opacity: 1;
-    }
-    65% {
-        transform: translateX(-3px);
-        opacity: 0.82;
-    }
-}
-
-.ts-carousel-hint {
-    display: none;
-}
-
 .ts-hero {
     position: relative;
     padding: 0 0 6rem;
@@ -3645,6 +3625,10 @@ body.ts-page--gallery {
         scroll-snap-align: start;
     }
 
+    .ts-carousel-container {
+        position: relative;
+    }
+
     .ts-nav__checkbox:checked + .ts-nav__toggle span:nth-child(1) {
         transform: translateY(9px) rotate(45deg);
     }
@@ -3811,60 +3795,6 @@ body.ts-page--gallery {
     .ts-usecase-card,
     .ts-advantage {
         scroll-snap-align: start;
-    }
-
-    .ts-usecases__grid,
-    .ts-advantages__grid {
-        position: relative;
-    }
-
-    .ts-carousel-hint {
-        position: absolute;
-        top: 50%;
-        right: clamp(0.45rem, 2vw, 1rem);
-        transform: translate3d(0, -50%, 0);
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-        padding: 0.45rem 0.9rem;
-        border-radius: 999px;
-        background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(246, 196, 69, 0.92) 100%);
-        box-shadow: 0 14px 32px rgba(60, 74, 31, 0.25);
-        color: #2f3b21;
-        font-size: 0.78rem;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        text-transform: uppercase;
-        pointer-events: none;
-        z-index: 6;
-        opacity: 1;
-        transition: opacity 0.35s ease, transform 0.35s ease, visibility 0.35s ease;
-    }
-
-    .ts-carousel-hint__text {
-        line-height: 1;
-        white-space: nowrap;
-    }
-
-    .ts-carousel-hint__arrow {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 1.4rem;
-        height: 1.4rem;
-        border-radius: 999px;
-        background: rgba(52, 63, 33, 0.95);
-        color: #ffffff;
-        font-size: 0.85rem;
-        line-height: 1;
-        animation: ts-carousel-hint 2.4s ease-in-out infinite;
-    }
-
-    .ts-usecases__grid.ts-carousel-hint-hidden .ts-carousel-hint,
-    .ts-advantages__grid.ts-carousel-hint-hidden .ts-carousel-hint {
-        opacity: 0;
-        visibility: hidden;
-        transform: translate3d(0, -50%, 0) scale(0.9);
     }
 
     .ts-usecase-card {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const carouselContainers = Array.from(
         document.querySelectorAll('.ts-usecases__grid, .ts-advantages__grid'),
     );
-    const carouselHintMedia = window.matchMedia('(max-width: 768px)');
+    const carouselMobileMedia = window.matchMedia('(max-width: 960px)');
     let scrollTicking = false;
 
     const addMediaQueryListener = (mediaQueryList, callback) => {
@@ -82,88 +82,26 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    const hideCarouselHint = (container, persist = false) => {
-        if (persist) {
-            container.dataset.carouselHintDismissed = 'true';
-        }
+    const syncCarouselAnimationForMobile = () => {
+        const shouldReveal = carouselMobileMedia.matches;
 
-        if (!container.classList.contains('ts-carousel-hint-hidden')) {
-            container.classList.add('ts-carousel-hint-hidden');
-        }
-    };
+        carouselContainers.forEach((container) => {
+            const animatedItems = container.querySelectorAll('[data-animate]');
 
-    const showCarouselHint = (container) => {
-        container.classList.remove('ts-carousel-hint-hidden');
-    };
-
-    const shouldShowCarouselHint = (container) =>
-        carouselHintMedia.matches && container.scrollWidth - container.clientWidth > 4;
-
-    const evaluateCarouselHint = (container) => {
-        if (container.dataset.carouselHintDismissed === 'true') {
-            hideCarouselHint(container);
-            return;
-        }
-
-        if (shouldShowCarouselHint(container)) {
-            showCarouselHint(container);
-        } else {
-            hideCarouselHint(container);
-        }
-    };
-
-    let carouselHintFrame = null;
-
-    const queueCarouselHintRefresh = () => {
-        if (carouselHintFrame !== null) {
-            return;
-        }
-
-        carouselHintFrame = requestAnimationFrame(() => {
-            carouselHintFrame = null;
-            carouselContainers.forEach((container) => {
-                evaluateCarouselHint(container);
+            animatedItems.forEach((item) => {
+                if (shouldReveal) {
+                    item.classList.add('is-visible');
+                    item.dataset.carouselMobileRevealed = 'true';
+                } else if (item.dataset.carouselMobileRevealed === 'true') {
+                    item.classList.remove('is-visible');
+                    delete item.dataset.carouselMobileRevealed;
+                }
             });
         });
     };
 
-    carouselContainers.forEach((container) => {
-        ensureCarouselHintElement(container);
-
-        const dismissCarouselHint = () => {
-            hideCarouselHint(container, true);
-        };
-
-        const onCarouselScroll = () => {
-            if (container.scrollLeft > 4) {
-                dismissCarouselHint();
-                container.removeEventListener('scroll', onCarouselScroll);
-            }
-        };
-
-        container.addEventListener('scroll', onCarouselScroll, { passive: true });
-
-        const onPointerIntent = () => {
-            dismissCarouselHint();
-            container.removeEventListener('touchstart', onPointerIntent);
-            container.removeEventListener('mousedown', onPointerIntent);
-        };
-
-        container.addEventListener('touchstart', onPointerIntent, { passive: true });
-        container.addEventListener('mousedown', onPointerIntent);
-
-        container.addEventListener('keydown', (event) => {
-            if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
-                dismissCarouselHint();
-            }
-        });
-    });
-
-    queueCarouselHintRefresh();
-    window.addEventListener('load', queueCarouselHintRefresh);
-    window.addEventListener('resize', queueCarouselHintRefresh);
-    window.addEventListener('orientationchange', queueCarouselHintRefresh);
-    addMediaQueryListener(carouselHintMedia, queueCarouselHintRefresh);
+    syncCarouselAnimationForMobile();
+    addMediaQueryListener(carouselMobileMedia, syncCarouselAnimationForMobile);
 
     const onScroll = () => {
         if (scrollTicking) {
@@ -583,27 +521,3 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 });
-    const ensureCarouselHintElement = (container) => {
-        if (container.querySelector('.ts-carousel-hint')) {
-            return;
-        }
-
-        const hint = document.createElement('div');
-        hint.className = 'ts-carousel-hint';
-        hint.setAttribute('aria-hidden', 'true');
-
-        const label = document.createElement('span');
-        label.className = 'ts-carousel-hint__text';
-        label.textContent = 'Свайпните';
-
-        const arrow = document.createElement('span');
-        arrow.className = 'ts-carousel-hint__arrow';
-        arrow.setAttribute('aria-hidden', 'true');
-        arrow.textContent = '→';
-
-        hint.appendChild(label);
-        hint.appendChild(arrow);
-
-        container.appendChild(hint);
-    };
-

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
                     <h2 id="ts-usecases-title">Применение интеллектуальных роботов по отделам</h2>
                     <p>Посмотрите, какие задачи мы закрываем уже на старте проектов.</p>
                 </div>
-                <div class="ts-usecases__grid">
+                <div class="ts-usecases__grid ts-carousel-container">
                     <article class="ts-usecase-card" data-animate="lift" data-animate-delay="0">
                         <span class="ts-usecase-card__index" aria-hidden="true">01</span>
                         <div class="ts-usecase-card__content">
@@ -363,7 +363,7 @@
                     <h2>Конкурентные преимущества Technostation</h2>
                     <p>Сосредоточились на ключевых факторах, которые дают быстрый эффект клиентам.</p>
                 </div>
-                <div class="ts-advantages__grid">
+                <div class="ts-advantages__grid ts-carousel-container">
                     <article class="ts-advantage" data-animate="lift" data-animate-delay="0">
                         <div class="ts-advantage__icon" aria-hidden="true">
                             <span class="ts-advantage__spark"></span>


### PR DESCRIPTION
## Summary
- remove the mobile carousel hint overlay so the carousels no longer render an arrow badge
- ensure the use case and advantage carousels reveal every card immediately on mobile viewports

## Testing
- not run (static site changes)

------
https://chatgpt.com/codex/tasks/task_e_68e6452b1d508330a07041b9bb43613f