### PR TITLE
Fix mobile team card width alignment

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3852,10 +3852,11 @@ body.ts-page--gallery {
     }
 
     .ts-grid--team {
-        justify-items: center;
+        justify-items: stretch;
     }
 
     .ts-team-card {
+        width: 100%;
         justify-items: center;
         text-align: center;
     }


### PR DESCRIPTION
## Summary
- ensure mobile team card grid stretches cards to full width
- force team cards to span the available column on small screens for consistent padding

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e64e2653b483309f80b991b84d37c6