### PR TITLE
Fix mobile visibility of case gallery cards

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const isSubpage = document.body.classList.contains('ts-subpage');
     const carouselContainers = Array.from(
         document.querySelectorAll(
-            '.ts-usecases__grid, .ts-advantages__grid, .ts-services__list, .ts-portfolio__list',
+            '.ts-usecases__grid, .ts-advantages__grid, .ts-services__list, .ts-portfolio__list, .ts-video-gallery__grid',
         ),
     );
     const carouselMobileMedia = window.matchMedia('(max-width: 960px)');


### PR DESCRIPTION
## Summary
- include the video gallery grid in the list of mobile carousel containers so its cards reveal on small screens

## Testing
- Manual verification on mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68e64fcc9f58833084c243f4e3e69e77