### PR TITLE
Fix mobile privacy policy heading size

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3410,6 +3410,10 @@ body.ts-page--gallery {
         padding: 3.25rem 0 2.75rem;
     }
 
+    .ts-subheader__intro h1 {
+        font-size: clamp(2rem, 7vw, 2.6rem);
+    }
+
     .ts-subheader__summary {
         font-size: 1rem;
     }


### PR DESCRIPTION
## Summary
- decrease the privacy policy hero heading size on smaller screens so it fits within the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e650b48fcc83308948d230b4f1b669