### PR TITLE
Disable animations on client cases page

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,9 +9,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const scrollHints = document.querySelectorAll('.ts-subheader__scroll-hint');
     const floatingCta = document.querySelector('.ts-floating-cta');
     const isSubpage = document.body.classList.contains('ts-subpage');
+    const isGalleryPage = document.body.classList.contains('ts-page--gallery');
     const carouselContainers = Array.from(
         document.querySelectorAll(
-            '.ts-usecases__grid, .ts-advantages__grid, .ts-services__list, .ts-portfolio__list',
+            '.ts-usecases__grid, .ts-advantages__grid, .ts-services__list, .ts-portfolio__list, .ts-video-gallery__grid',
         ),
     );
     const carouselMobileMedia = window.matchMedia('(max-width: 960px)');
@@ -40,7 +41,8 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
-    const shouldUseObserver = supportsIntersectionObserver && !prefersReducedMotion.matches && !isSubpage;
+    const shouldUseObserver =
+        supportsIntersectionObserver && !prefersReducedMotion.matches && !isSubpage && !isGalleryPage;
 
     anchorLinks.forEach((link) => {
         link.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- stop enabling scroll-triggered animations on the client cases gallery page so all cards render immediately

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e64fcc9f58833084c243f4e3e69e77