### PR TITLE
Remove text overlays from portfolio SVG artwork

### DIFF
--- a/assets/images/cases/case-1.svg
+++ b/assets/images/cases/case-1.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420">
+  <defs>
+    <linearGradient id="case1-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#151c4b" />
+      <stop offset="100%" stop-color="#233b7a" />
+    </linearGradient>
+    <radialGradient id="case1-glow" cx="0.25" cy="0.2" r="0.7">
+      <stop offset="0%" stop-color="#5ec6ff" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#5ec6ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect fill="url(#case1-bg)" width="640" height="420" rx="28" />
+  <rect fill="url(#case1-glow)" width="640" height="420" />
+  <g stroke="#6fe6ff" stroke-width="1.6" opacity="0.7">
+    <path d="M120 140c45 34 96 60 150 54 88-10 137-120 252-110" fill="none" />
+    <path d="M100 250c60 12 118 64 182 66 86 2 126-56 258-32" fill="none" />
+  </g>
+  <g fill="#89f1ff" opacity="0.9">
+    <circle cx="118" cy="138" r="10" />
+    <circle cx="218" cy="188" r="8" />
+    <circle cx="322" cy="154" r="9" />
+    <circle cx="476" cy="110" r="12" />
+    <circle cx="530" cy="260" r="10" />
+    <circle cx="306" cy="300" r="11" />
+  </g>
+  <g fill="#5ec6ff" opacity="0.35">
+    <rect x="60" y="330" width="180" height="10" rx="5" />
+    <rect x="260" y="348" width="120" height="10" rx="5" />
+    <rect x="120" y="364" width="140" height="10" rx="5" />
+    <rect x="300" y="332" width="72" height="10" rx="5" opacity="0.6" />
+    <rect x="440" y="350" width="110" height="10" rx="5" opacity="0.45" />
+  </g>
+</svg>

--- a/assets/images/cases/case-2.svg
+++ b/assets/images/cases/case-2.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420">
+  <defs>
+    <linearGradient id="case2-bg" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#18263a" />
+      <stop offset="100%" stop-color="#2b5fa7" />
+    </linearGradient>
+    <linearGradient id="case2-card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2ed6c8" />
+      <stop offset="100%" stop-color="#6f7cff" />
+    </linearGradient>
+  </defs>
+  <rect fill="url(#case2-bg)" width="640" height="420" rx="28" />
+  <g opacity="0.35" fill="none" stroke="#9ce8ff" stroke-width="1.5">
+    <path d="M60 160h520" />
+    <path d="M80 220h480" />
+    <path d="M120 280h420" />
+    <path d="M140 120h400" />
+  </g>
+  <g transform="translate(160 90)">
+    <rect x="0" y="0" width="320" height="220" rx="28" fill="#0b172b" opacity="0.65" />
+    <rect x="26" y="26" width="268" height="168" rx="22" fill="url(#case2-card)" />
+    <circle cx="94" cy="110" r="36" fill="#0b172b" opacity="0.4" />
+    <path d="M80 112l12 12 20-28" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+    <g transform="translate(150 60)" fill="#0b172b">
+      <rect x="0" y="0" width="96" height="14" rx="7" />
+      <rect x="0" y="32" width="124" height="14" rx="7" opacity="0.6" />
+      <rect x="0" y="64" width="84" height="14" rx="7" opacity="0.35" />
+    </g>
+  </g>
+  <g fill="#6f7cff" opacity="0.45">
+    <circle cx="120" cy="356" r="18" />
+    <circle cx="200" cy="360" r="12" opacity="0.6" />
+    <circle cx="260" cy="350" r="16" opacity="0.7" />
+    <circle cx="340" cy="362" r="14" opacity="0.55" />
+    <circle cx="420" cy="356" r="20" opacity="0.65" />
+    <circle cx="500" cy="360" r="13" opacity="0.5" />
+  </g>
+</svg>

--- a/assets/images/cases/case-3.svg
+++ b/assets/images/cases/case-3.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420">
+  <defs>
+    <linearGradient id="case3-bg" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0f1d28" />
+      <stop offset="100%" stop-color="#16526a" />
+    </linearGradient>
+    <linearGradient id="case3-chart" x1="0" y1="1" x2="0.9" y2="0">
+      <stop offset="0%" stop-color="#24f1b0" />
+      <stop offset="100%" stop-color="#7bffdd" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="28" fill="url(#case3-bg)" />
+  <g opacity="0.35" stroke="#47d5ff" stroke-width="1.6" fill="none">
+    <path d="M80 320c80-120 160-180 240-120s160-20 240-160" />
+    <path d="M60 260c60-60 180-60 240-10s120 52 220 0" />
+  </g>
+  <g transform="translate(120 120)">
+    <rect width="400" height="220" rx="26" fill="#081017" opacity="0.65" />
+    <g transform="translate(48 52)">
+      <path d="M0 120h48l40-72 60 48 54-96 70 60 50-92 60 44" fill="none" stroke="#87f5ff" stroke-width="6" stroke-linecap="round" />
+      <rect x="28" y="40" width="32" height="80" rx="12" fill="url(#case3-chart)" />
+      <rect x="108" y="24" width="32" height="96" rx="12" fill="url(#case3-chart)" opacity="0.75" />
+      <rect x="188" y="58" width="32" height="62" rx="12" fill="url(#case3-chart)" opacity="0.6" />
+      <rect x="268" y="10" width="32" height="110" rx="12" fill="url(#case3-chart)" opacity="0.9" />
+    </g>
+    <g fill="#24f1b0" opacity="0.35">
+      <circle cx="70" cy="32" r="10" />
+      <circle cx="124" cy="28" r="8" />
+      <circle cx="176" cy="36" r="9" />
+      <circle cx="228" cy="30" r="7" />
+      <circle cx="282" cy="34" r="11" />
+    </g>
+  </g>
+  <g stroke="#47d5ff" stroke-width="3" opacity="0.4" fill="none" stroke-linecap="round">
+    <path d="M80 350h120" />
+    <path d="M220 360h160" opacity="0.6" />
+    <path d="M400 348h140" opacity="0.45" />
+    <path d="M120 370h90" opacity="0.55" />
+  </g>
+</svg>

--- a/assets/images/cases/case-4.svg
+++ b/assets/images/cases/case-4.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420">
+  <defs>
+    <linearGradient id="case4-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#20144a" />
+      <stop offset="100%" stop-color="#502a7c" />
+    </linearGradient>
+    <linearGradient id="case4-card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff8b6e" />
+      <stop offset="100%" stop-color="#ffd36f" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="28" fill="url(#case4-bg)" />
+  <g opacity="0.3" fill="none" stroke="#ffd8ff" stroke-width="1.4">
+    <circle cx="160" cy="130" r="60" />
+    <circle cx="320" cy="210" r="120" />
+    <circle cx="520" cy="160" r="90" />
+  </g>
+  <g transform="translate(150 110)">
+    <rect x="0" y="0" width="340" height="220" rx="24" fill="#140b33" opacity="0.6" />
+    <rect x="30" y="30" width="280" height="160" rx="22" fill="url(#case4-card)" />
+    <g transform="translate(70 50)" fill="#140b33">
+      <circle cx="40" cy="40" r="36" opacity="0.8" />
+      <path d="M40 18c12 0 22 10 22 22s-10 22-22 22-22-10-22-22 10-22 22-22z" fill="#fff" opacity="0.5" />
+      <path d="M12 92c8-18 22-28 28-28h0c6 0 20 10 28 28" fill="#fff" opacity="0.5" />
+    </g>
+    <g transform="translate(160 62)" fill="#140b33">
+      <rect x="0" y="0" width="120" height="16" rx="8" />
+      <rect x="0" y="34" width="160" height="16" rx="8" opacity="0.7" />
+      <rect x="0" y="68" width="100" height="16" rx="8" opacity="0.45" />
+    </g>
+  </g>
+  <g opacity="0.4" fill="none" stroke="#ffd36f" stroke-width="3" stroke-linecap="round">
+    <path d="M80 350c40-20 80-20 120 0" />
+    <path d="M240 352c32-18 70-18 108 0" opacity="0.6" />
+    <path d="M380 356c36-20 76-20 116 0" opacity="0.5" />
+    <path d="M520 354c18-10 38-10 58 0" opacity="0.45" />
+  </g>
+</svg>

--- a/assets/images/cases/case-5.svg
+++ b/assets/images/cases/case-5.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420">
+  <defs>
+    <linearGradient id="case5-bg" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#102412" />
+      <stop offset="100%" stop-color="#2f5f36" />
+    </linearGradient>
+    <linearGradient id="case5-grid" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#8cffa5" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#f0ff9b" stop-opacity="0.05" />
+    </linearGradient>
+    <linearGradient id="case5-block" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f6d26f" />
+      <stop offset="100%" stop-color="#ff9c4a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="28" fill="url(#case5-bg)" />
+  <path d="M80 320h480" stroke="url(#case5-grid)" stroke-width="2" opacity="0.6" />
+  <path d="M120 260h400" stroke="url(#case5-grid)" stroke-width="2" opacity="0.6" />
+  <path d="M160 200h320" stroke="url(#case5-grid)" stroke-width="2" opacity="0.6" />
+  <g transform="translate(140 110)" fill="#0c1a0e" opacity="0.65">
+    <rect x="0" y="0" width="360" height="220" rx="24" />
+  </g>
+  <g transform="translate(176 140)">
+    <rect x="0" y="0" width="108" height="148" rx="18" fill="url(#case5-block)" />
+    <rect x="132" y="24" width="112" height="124" rx="18" fill="url(#case5-block)" opacity="0.8" />
+    <rect x="268" y="48" width="84" height="100" rx="18" fill="url(#case5-block)" opacity="0.6" />
+    <g transform="translate(0 172)" fill="#f5fdd8" opacity="0.35">
+      <rect x="14" y="6" width="80" height="12" rx="6" />
+      <rect x="146" y="6" width="64" height="12" rx="6" />
+      <rect x="278" y="6" width="56" height="12" rx="6" />
+    </g>
+  </g>
+  <g fill="#8cffa5" opacity="0.4">
+    <rect x="60" y="344" width="160" height="12" rx="6" />
+    <rect x="240" y="360" width="120" height="12" rx="6" opacity="0.65" />
+    <rect x="380" y="346" width="150" height="12" rx="6" opacity="0.5" />
+    <rect x="540" y="358" width="60" height="12" rx="6" opacity="0.45" />
+  </g>
+</svg>

--- a/assets/images/cases/case-6.svg
+++ b/assets/images/cases/case-6.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420">
+  <defs>
+    <linearGradient id="case6-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f233f" />
+      <stop offset="100%" stop-color="#184b6f" />
+    </linearGradient>
+    <linearGradient id="case6-line" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#95ffcf" />
+      <stop offset="100%" stop-color="#4de2ff" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="28" fill="url(#case6-bg)" />
+  <g opacity="0.3" fill="none" stroke="#7bcbff" stroke-width="1.4">
+    <path d="M100 120h420c40 0 80 32 80 72s-40 72-80 72H120c-44 0-80 36-80 80" />
+    <path d="M140 80c30 0 60 24 60 54s-30 54-60 54" />
+  </g>
+  <g transform="translate(150 120)">
+    <rect width="340" height="200" rx="24" fill="#071523" opacity="0.7" />
+    <g transform="translate(44 48)">
+      <path d="M0 110l72-54 56 36 54-50 58 42 60-78" fill="none" stroke="url(#case6-line)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+      <g fill="#0c2b2b" opacity="0.4">
+        <rect x="0" y="0" width="96" height="20" rx="10" />
+        <rect x="0" y="134" width="260" height="16" rx="8" />
+      </g>
+      <circle cx="72" cy="56" r="10" fill="#95ffcf" />
+      <circle cx="128" cy="86" r="10" fill="#95ffcf" opacity="0.8" />
+      <circle cx="182" cy="36" r="10" fill="#95ffcf" opacity="0.7" />
+      <circle cx="240" cy="78" r="10" fill="#95ffcf" opacity="0.9" />
+    </g>
+  </g>
+  <g stroke="#4de2ff" stroke-width="2.6" opacity="0.45" fill="none" stroke-linecap="round">
+    <path d="M60 348c24 16 48 16 72 0" />
+    <path d="M160 352c28 18 58 18 86 0" opacity="0.6" />
+    <path d="M272 350c30 20 64 20 94 0" opacity="0.55" />
+    <path d="M392 356c26 16 52 16 78 0" opacity="0.5" />
+    <path d="M506 352c20 14 40 14 60 0" opacity="0.45" />
+  </g>
+</svg>

--- a/assets/images/cases/case-7.svg
+++ b/assets/images/cases/case-7.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420">
+  <defs>
+    <linearGradient id="case7-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c0f3f" />
+      <stop offset="100%" stop-color="#2d2770" />
+    </linearGradient>
+    <radialGradient id="case7-spot" cx="0.3" cy="0.3" r="0.6">
+      <stop offset="0%" stop-color="#ff78f2" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#ff78f2" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="case7-cards" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#66f0ff" />
+      <stop offset="100%" stop-color="#7d74ff" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="28" fill="url(#case7-bg)" />
+  <rect width="640" height="420" fill="url(#case7-spot)" />
+  <g transform="translate(140 110)">
+    <rect x="0" y="0" width="360" height="220" rx="28" fill="#0f0a2a" opacity="0.7" />
+    <g transform="translate(40 44)" fill="none" stroke="url(#case7-cards)" stroke-width="6" stroke-linejoin="round">
+      <rect x="0" y="0" width="116" height="148" rx="18" />
+      <rect x="92" y="28" width="124" height="148" rx="20" />
+      <rect x="192" y="12" width="116" height="148" rx="18" />
+    </g>
+    <g transform="translate(60 66)" fill="#ffb8ff" opacity="0.45">
+      <rect x="0" y="8" width="88" height="12" rx="6" />
+      <rect x="108" y="50" width="104" height="12" rx="6" opacity="0.7" />
+      <rect x="212" y="8" width="96" height="12" rx="6" opacity="0.6" />
+    </g>
+    <path d="M60 156h240" stroke="#ffb8ff" stroke-width="4" stroke-linecap="round" opacity="0.6" />
+    <g transform="translate(60 170)" fill="#ffb8ff" opacity="0.6">
+      <rect x="0" y="0" width="72" height="12" rx="6" />
+      <rect x="96" y="0" width="96" height="12" rx="6" />
+      <rect x="216" y="0" width="72" height="12" rx="6" />
+    </g>
+  </g>
+  <g fill="#ff78f2" opacity="0.35">
+    <circle cx="120" cy="356" r="18" />
+    <circle cx="200" cy="352" r="14" opacity="0.6" />
+    <circle cx="280" cy="360" r="16" opacity="0.55" />
+    <circle cx="360" cy="352" r="12" opacity="0.5" />
+    <circle cx="440" cy="358" r="15" opacity="0.6" />
+    <circle cx="520" cy="354" r="13" opacity="0.45" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -552,7 +552,7 @@
                                     <h3>Роботизация межфилиальных процессов в международной производственной корпорации</h3>
                                 </div>
                                 <div class="ts-portfolio__panel-media">
-                                    <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=960&q=80" alt="Команда анализирует глобальные бизнес-процессы" />
+                                    <img src="assets/images/cases/case-1.svg" alt="Команда анализирует глобальные бизнес-процессы" />
                                 </div>
                             </header>
                             <div class="ts-portfolio__panel-body">
@@ -622,7 +622,7 @@
                                     <h3>Роботизация обработки заказов в интернет-магазине</h3>
                                 </div>
                                 <div class="ts-portfolio__panel-media">
-                                    <img src="https://images.unsplash.com/photo-1556740749-887f6717d7e4?auto=format&fit=crop&w=960&q=80" alt="Специалист интернет-магазина работает с заказами" />
+                                    <img src="assets/images/cases/case-2.svg" alt="Специалист интернет-магазина работает с заказами" />
                                 </div>
                             </header>
                             <div class="ts-portfolio__panel-body">
@@ -692,7 +692,7 @@
                                     <h3>Оптимизация бухгалтерских процессов в финансовой компании</h3>
                                 </div>
                                 <div class="ts-portfolio__panel-media">
-                                    <img src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=960&q=80" alt="Финансовый отдел готовит отчётность" />
+                                    <img src="assets/images/cases/case-3.svg" alt="Финансовый отдел готовит отчётность" />
                                 </div>
                             </header>
                             <div class="ts-portfolio__panel-body">
@@ -761,7 +761,7 @@
                                     <h3>Роботизация HR-процессов в крупной компании</h3>
                                 </div>
                                 <div class="ts-portfolio__panel-media">
-                                    <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=960&q=80" alt="HR-команда обсуждает автоматизацию подбора" />
+                                    <img src="assets/images/cases/case-4.svg" alt="HR-команда обсуждает автоматизацию подбора" />
                                 </div>
                             </header>
                             <div class="ts-portfolio__panel-body">
@@ -830,7 +830,7 @@
                                     <h3>Роботизация административных процессов в строительной компании</h3>
                                 </div>
                                 <div class="ts-portfolio__panel-media">
-                                    <img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=960&q=80" alt="Строительная компания контролирует документы" />
+                                    <img src="assets/images/cases/case-5.svg" alt="Строительная компания контролирует документы" />
                                 </div>
                             </header>
                             <div class="ts-portfolio__panel-body">
@@ -899,7 +899,7 @@
                                     <h3>Роботизация обработки актов сверки в торговой компании</h3>
                                 </div>
                                 <div class="ts-portfolio__panel-media">
-                                    <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=960&q=80" alt="Специалисты проверяют финансовые отчёты" />
+                                    <img src="assets/images/cases/case-6.svg" alt="Специалисты проверяют финансовые отчёты" />
                                 </div>
                             </header>
                             <div class="ts-portfolio__panel-body">
@@ -968,7 +968,7 @@
                                     <h3>Роботизация поиска тендеров и подготовки документов</h3>
                                 </div>
                                 <div class="ts-portfolio__panel-media">
-                                    <img src="https://images.unsplash.com/photo-1521737604893-ccfbe1661d4c?auto=format&fit=crop&w=960&q=80" alt="Команда анализирует тендерные предложения" />
+                                    <img src="assets/images/cases/case-7.svg" alt="Команда анализирует тендерные предложения" />
                                 </div>
                             </header>
                             <div class="ts-portfolio__panel-body">


### PR DESCRIPTION
## Summary
- replace textual captions within each portfolio SVG with abstract geometric accents
- retain the updated local artwork while ensuring no inline text remains in the illustrations

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68e657ccc15c8330b219550652e85e5a